### PR TITLE
PR: Add runcell to spydercustomize

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -616,6 +616,17 @@ def _get_globals():
     ipython_shell = get_ipython()
     return ipython_shell.user_ns
 
+def run_umr():
+    global __umr__
+    if os.environ.get("SPY_UMR_ENABLED", "").lower() == "true":
+        if __umr__ is None:
+            namelist = os.environ.get("SPY_UMR_NAMELIST", None)
+            if namelist is not None:
+                namelist = namelist.split(',')
+            __umr__ = UserModuleReloader(namelist=namelist)
+        else:
+            verbose = os.environ.get("SPY_UMR_VERBOSE", "").lower() == "true"
+            __umr__.run(verbose=verbose)
 
 def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
     """
@@ -630,16 +641,7 @@ def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
         # UnicodeError, TypeError --> eventually raised in Python 2
         # AttributeError --> systematically raised in Python 3
         pass
-    global __umr__
-    if os.environ.get("SPY_UMR_ENABLED", "").lower() == "true":
-        if __umr__ is None:
-            namelist = os.environ.get("SPY_UMR_NAMELIST", None)
-            if namelist is not None:
-                namelist = namelist.split(',')
-            __umr__ = UserModuleReloader(namelist=namelist)
-        else:
-            verbose = os.environ.get("SPY_UMR_VERBOSE", "").lower() == "true"
-            __umr__.run(verbose=verbose)
+    run_umr()
     if args is not None and not isinstance(args, basestring):
         raise TypeError("expected a character buffer object")
     if namespace is None:
@@ -699,21 +701,9 @@ def runcell(cell_name, filename):
         # UnicodeError, TypeError --> eventually raised in Python 2
         # AttributeError --> systematically raised in Python 3
         pass
-    global __umr__
-    if os.environ.get("SPY_UMR_ENABLED", "").lower() == "true":
-        if __umr__ is None:
-            namelist = os.environ.get("SPY_UMR_NAMELIST", None)
-            if namelist is not None:
-                namelist = namelist.split(',')
-            __umr__ = UserModuleReloader(namelist=namelist)
-        else:
-            verbose = os.environ.get("SPY_UMR_VERBOSE", "").lower() == "true"
-            __umr__.run(verbose=verbose)
-
+    run_umr()
     namespace = _get_globals()
     namespace['__file__'] = filename
-
-    from IPython.core.getipython import get_ipython
     ipython_shell = get_ipython()
     try:
         cell_code = ipython_shell.cell_code

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -608,13 +608,14 @@ if "SPYDER_EXCEPTHOOK" in os.environ:
     set_post_mortem()
 
 
-#==============================================================================
+# ==============================================================================
 # runfile and debugfile commands
-#==============================================================================
+# ==============================================================================
 def _get_globals():
     """Return current namespace"""
     ipython_shell = get_ipython()
     return ipython_shell.user_ns
+
 
 def run_umr():
     """Runs the user module reloader"""
@@ -628,6 +629,7 @@ def run_umr():
         else:
             verbose = os.environ.get("SPY_UMR_VERBOSE", "").lower() == "true"
             __umr__.run(verbose=verbose)
+
 
 def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
     """
@@ -674,27 +676,25 @@ def runfile(filename, args=None, wdir=None, namespace=None, post_mortem=False):
     sys.argv = ['']
     namespace.pop('__file__')
 
+
 builtins.runfile = runfile
 
 
-def runcell(cell_name, filename):
+def runcell(cellname, filename):
     """
-    Runs a code cell from an editor as a file.
+    Run a code cell from an editor as a file.
 
-    Currently looks for code in in a ipython property called `cell_code`.
-    This property must be set by the editor prior to calling this function
+    Currently looks for code in in a `ipython` property called `cell_code`.
+    This property must be set by the editor prior to calling this function.
     This function deletes the contents of `cell_code` upon completion.
-
-    The filename is needed to allow for proper traceback links.
-
-    The cell_name is used currently as a reference in the history log of which
-    cell was run with the command. It is currently unused in the function.
 
     Parameters
     ----------
-
-    cell_name: The name of the code cell (string)
-    filename: The name of the file containing the code cell (string)
+    cellname : str
+        Used as a reference in the history log of which
+        cell was run with the fuction. This variable is not used.
+    filename : str
+        Needed to allow for proper traceback links.
     """
     try:
         filename = filename.decode('utf-8')
@@ -703,18 +703,16 @@ def runcell(cell_name, filename):
         # AttributeError --> systematically raised in Python 3
         pass
     run_umr()
-    namespace = _get_globals()
-    namespace['__file__'] = filename
     ipython_shell = get_ipython()
     try:
         cell_code = ipython_shell.cell_code
     except AttributeError:
         _print("--Run Cell Error--\n"
-               "Please use only in editor")
+               "Please use only through Spyder's Editor; "
+               "shouldn't be called manually from the console")
         return
-    exec(compile(cell_code, filename, 'exec'), namespace)
+    ipython_shell.run_cell(cell_code)
     del ipython_shell.cell_code
-    namespace.pop('__file__')
 
 
 builtins.runcell = runcell
@@ -735,6 +733,7 @@ def debugfile(filename, args=None, wdir=None, post_mortem=False):
     if os.name == 'nt':
         filename = filename.replace('\\', '/')
     debugger.run("runfile(%r, args=%r, wdir=%r)" % (filename, args, wdir))
+
 
 builtins.debugfile = debugfile
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -617,6 +617,7 @@ def _get_globals():
     return ipython_shell.user_ns
 
 def run_umr():
+    """Runs the user module reloader"""
     global __umr__
     if os.environ.get("SPY_UMR_ENABLED", "").lower() == "true":
         if __umr__ is None:

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -618,7 +618,7 @@ def _get_globals():
 
 
 def run_umr():
-    """Runs the user module reloader"""
+    """Run the user module reloader."""
     global __umr__
     if os.environ.get("SPY_UMR_ENABLED", "").lower() == "true":
         if __umr__ is None:

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -684,7 +684,7 @@ def runcell(cellname, filename):
     """
     Run a code cell from an editor as a file.
 
-    Currently looks for code in in a `ipython` property called `cell_code`.
+    Currently looks for code in an `ipython` property called `cell_code`.
     This property must be set by the editor prior to calling this function.
     This function deletes the contents of `cell_code` upon completion.
 


### PR DESCRIPTION
<!--- Before submitting your pull request --->
<!--- please complete as much as possible of the following checklist: --->

### Pull Request Checklist

* [x] Based your PR on the latest version of the correct branch (master or 3.x)
* [x] Followed [PEP8](https://www.python.org/dev/peps/pep-0008/) for code style
* [x] Ensured your pull request hasn't eliminated unrelated blank lines/spaces,
      modified the ``spyder/defaults`` directory, or added new icons/assets
* [x] Wrote at least one-line docstrings for any new functions
* [ ] Added at least one unit test covering the changes, if at all possible
* [x] Described your changes and the motivation for them below
* [x] Noted what issue(s) this pull request resolves, creating one if needed


## Description of Changes

This PR makes a function that runs a cell instead of copying the cell contents into the current console. With this function can allow for correct traceback links when used with https://github.com/spyder-ide/spyder/pull/7310

### Implementation

The function reads a code section from a variable in the ipython namespace of the console. The function executes this code then deletes the variable. The function displays an error if it is run from the console. The variable could remain so the function can run the last cell, but it's not obvious that it won't reflect any subsequent changes to the cell block in the editor. The cell_mane is currently only used to show the user a simple history of what cells have been run


### Issue(s) Resolved

<!--- outstanding issue; create a new one if no relevant issue exists. --->
<!--- List the issue(s) below, in the form "Fixes #1234" . One per line.--->

https://github.com/spyder-ide/spyder/issues/7113


<!--- Thanks for your help making Spyder better for everyone! --->