### PR TITLE
PR: Add %matplotlib magic to the IPdb kernel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,30 +1,32 @@
 version: 2
 
+main: &main
+    machine: true
+    steps:
+      - checkout
+      - run:
+          command: docker pull dorowu/ubuntu-desktop-lxde-vnc:trusty
+      - run:
+          name: Install system packages
+          command: |
+            sudo apt-get -qq update
+            sudo apt-get install libegl1-mesa
+      - run:
+          command: ./.circleci/install.sh
+      - run:
+          command: ./.circleci/run_tests.sh
+
 jobs:
   python2.7:
-    machine: true
+    python2.7:
+    <<: *main
     environment:
       - PYTHON_VERSION: "2.7"
-    steps:
-      - checkout
-      - run:
-          command: docker pull continuumio/miniconda3:latest
-      - run:
-          command: ./.circleci/install.sh
-      - run:
-          command: ./.circleci/run_tests.sh
+
   python3.6:
-    machine: true
+    <<: *main
     environment:
       - PYTHON_VERSION: "3.6"
-    steps:
-      - checkout
-      - run:
-          command: docker pull continuumio/miniconda3:latest
-      - run:
-          command: ./.circleci/install.sh
-      - run:
-          command: ./.circleci/run_tests.sh
 
 workflows:
   version: 2

--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -2,8 +2,9 @@
 
 export TRAVIS_OS_NAME="linux"
 export CONDA_DEPENDENCIES_FLAGS="--quiet"
-export CONDA_DEPENDENCIES="ipykernel cloudpickle nomkl numpy pandas scipy pytest pytest-cov metakernel matplotlib"
-export PIP_DEPENDENCIES="codecov"
+export CONDA_DEPENDENCIES="ipykernel cloudpickle nomkl numpy pandas scipy \
+                           metakernel matplotlib qtconsole pytest pytest-cov"
+export PIP_DEPENDENCIES="codecov pytest-qt"
 
 echo -e "PYTHON = $PYTHON_VERSION \n============"
 git clone git://github.com/astropy/ci-helpers.git > /dev/null

--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -2,7 +2,7 @@
 
 export TRAVIS_OS_NAME="linux"
 export CONDA_DEPENDENCIES_FLAGS="--quiet"
-export CONDA_DEPENDENCIES="ipykernel cloudpickle nomkl numpy pandas scipy pytest pytest-cov metakernel"
+export CONDA_DEPENDENCIES="ipykernel cloudpickle nomkl numpy pandas scipy pytest pytest-cov metakernel matplotlib"
 export PIP_DEPENDENCIES="codecov"
 
 echo -e "PYTHON = $PYTHON_VERSION \n============"

--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -3,9 +3,14 @@
 export TRAVIS_OS_NAME="linux"
 export CONDA_DEPENDENCIES_FLAGS="--quiet"
 export CONDA_DEPENDENCIES="ipykernel cloudpickle nomkl numpy pandas scipy \
-                           metakernel matplotlib qtconsole pytest pytest-cov"
+                           pexpect matplotlib qtconsole pytest pytest-cov"
 export PIP_DEPENDENCIES="codecov pytest-qt"
 
 echo -e "PYTHON = $PYTHON_VERSION \n============"
 git clone git://github.com/astropy/ci-helpers.git > /dev/null
 source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+source $HOME/miniconda/etc/profile.d/conda.sh
+conda activate test
+
+# Install metakernel from master to verify that it doesn't break us
+pip install -q --no-deps git+https://github.com/Calysto/metakernel.git

--- a/.circleci/install.sh
+++ b/.circleci/install.sh
@@ -4,6 +4,7 @@ export TRAVIS_OS_NAME="linux"
 export CONDA_DEPENDENCIES_FLAGS="--quiet"
 export CONDA_DEPENDENCIES="ipykernel cloudpickle nomkl numpy pandas scipy \
                            pexpect matplotlib qtconsole pytest pytest-cov"
+export PIP_DEPENDENCIES_FLAGS="-q"
 export PIP_DEPENDENCIES="codecov pytest-qt"
 
 echo -e "PYTHON = $PYTHON_VERSION \n============"

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -3,7 +3,12 @@
 export PATH="$HOME/miniconda/bin:$PATH"
 source activate test
 
-pytest -x -vv --cov=spyder_kernels --cov-report=term-missing spyder_kernels
+# Install ipdb_kernel spec
+pip install -e .
+python spyder_kernels/ipdb install --user
+
+# Run tests
+pytest -x -vv --cov=spyder_kernels spyder_kernels
 
 if [ $? -ne 0 ]; then
     exit 1

--- a/.circleci/run_tests.sh
+++ b/.circleci/run_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export PATH="$HOME/miniconda/bin:$PATH"
-source activate test
+source $HOME/miniconda/etc/profile.d/conda.sh
+conda activate test
 
 # Install ipdb_kernel spec
 pip install -e .

--- a/spyder_kernels/ipdb/backend_inline.py
+++ b/spyder_kernels/ipdb/backend_inline.py
@@ -26,16 +26,17 @@ def get_image(figure):
     The idea to get png/svg from a figure was taken from
     https://stackoverflow.com/a/12145161/438386
     """
+    # Print figure to a bytes stream
     if PY2:
         data = io.StringIO()
     else:
         data = io.BytesIO()
-
     figure.canvas.print_figure(data, bbox_inches='tight')
-    metadata=_fetch_figure_metadata(figure)
 
-    # TODO: Passing metadata is making qtconsole crash
-    img = Image(data=data.getvalue())
+    # Get figure metadata
+    metadata = _fetch_figure_metadata(figure)
+
+    img = Image(data=data.getvalue(), metadata=metadata)
     return img
 
 

--- a/spyder_kernels/ipdb/backend_inline.py
+++ b/spyder_kernels/ipdb/backend_inline.py
@@ -14,8 +14,6 @@ ipykernel/pylab/backend_inline.py
 
 from ipykernel.pylab.backend_inline import _fetch_figure_metadata
 from IPython.display import Image
-import matplotlib
-from matplotlib._pylab_helpers import Gcf
 from metakernel.display import display
 
 from spyder_kernels.py3compat import io, PY2
@@ -45,6 +43,9 @@ def show():
     """
     Show all figures as PNG payloads sent to the Jupyter clients.
     """
+    import matplotlib
+    from matplotlib._pylab_helpers import Gcf
+
     try:
         for figure_manager in Gcf.get_all_fig_managers():
             display(get_image(figure_manager.canvas.figure))

--- a/spyder_kernels/ipdb/backend_inline.py
+++ b/spyder_kernels/ipdb/backend_inline.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2018- Spyder Kernels Contributors
+# Copyright (c) IPython Development Team.
+# Distributed under the terms of the Modified BSD License.
+# -----------------------------------------------------------------------------
+
+"""
+Functions for our inline backend.
+
+This is a simplified version of some functions present in
+ipykernel/pylab/backend_inline.py
+"""
+
+from ipykernel.pylab.backend_inline import _fetch_figure_metadata
+from IPython.display import Image
+import matplotlib
+from matplotlib._pylab_helpers import Gcf
+from metakernel.display import display
+
+from spyder_kernels.py3compat import io, PY2
+
+
+def get_image(figure):
+    """
+    Get image display object from a Matplotlib figure.
+
+    The idea to get png/svg from a figure was taken from
+    https://stackoverflow.com/a/12145161/438386
+    """
+    if PY2:
+        data = io.StringIO()
+    else:
+        data = io.BytesIO()
+
+    figure.canvas.print_png(data)
+    metadata=_fetch_figure_metadata(figure)
+
+    # TODO: Passing metadata is making qtconsole crash
+    img = Image(data=data.getvalue())
+    return img
+
+
+def show():
+    """
+    Show all figures as PNG payloads sent to the Jupyter clients.
+    """
+    try:
+        for figure_manager in Gcf.get_all_fig_managers():
+            display(get_image(figure_manager.canvas.figure))
+    finally:
+        if Gcf.get_all_fig_managers():
+            matplotlib.pyplot.close('all')

--- a/spyder_kernels/ipdb/backend_inline.py
+++ b/spyder_kernels/ipdb/backend_inline.py
@@ -33,7 +33,7 @@ def get_image(figure):
     else:
         data = io.BytesIO()
 
-    figure.canvas.print_png(data)
+    figure.canvas.print_figure(data, bbox_inches='tight')
     metadata=_fetch_figure_metadata(figure)
 
     # TODO: Passing metadata is making qtconsole crash

--- a/spyder_kernels/ipdb/kernel.py
+++ b/spyder_kernels/ipdb/kernel.py
@@ -174,8 +174,8 @@ class IPdbKernel(BaseKernelMixIn, MetaKernel):
         """Remove unnecessary magics from MetaKernel."""
         line_magics = ['activity', 'conversation', 'dot', 'get', 'include',
                        'install', 'install_magic', 'jigsaw', 'kernel', 'kx',
-                       'macro', 'parallel', 'pmap', 'px', 'run', 'scheme',
-                       'set']
+                       'macro', 'parallel', 'plot', 'pmap', 'px', 'run',
+                       'scheme', 'set']
         cell_magics = ['activity', 'brain', 'conversation', 'debug', 'dot',
                        'macro', 'processing', 'px', 'scheme', 'tutor']
 

--- a/spyder_kernels/ipdb/kernel.py
+++ b/spyder_kernels/ipdb/kernel.py
@@ -180,10 +180,16 @@ class IPdbKernel(BaseKernelMixIn, MetaKernel):
                        'macro', 'processing', 'px', 'scheme', 'tutor']
 
         for lm in line_magics:
-            self.line_magics.pop(lm)
+            try:
+                self.line_magics.pop(lm)
+            except KeyError:
+                pass
 
         for cm in cell_magics:
-            self.cell_magics.pop(cm)
+            try:
+                self.cell_magics.pop(cm)
+            except:
+                pass
 
     def _get_current_namespace(self, with_magics=False):
         """Get current namespace."""

--- a/spyder_kernels/ipdb/magics/matplotlib_magic.py
+++ b/spyder_kernels/ipdb/magics/matplotlib_magic.py
@@ -15,7 +15,7 @@ class MatplotlibMagic(Magic):
         """
         Matplotlib magic
 
-        You can set all backends you can with the IPython %Matplotlib
+        You can set all backends you can with the IPython %matplotlib
         magic.
         """
         gui, backend = self.kernel.ipyshell.enable_matplotlib(gui=gui)

--- a/spyder_kernels/ipdb/magics/matplotlib_magic.py
+++ b/spyder_kernels/ipdb/magics/matplotlib_magic.py
@@ -13,14 +13,13 @@ class MatplotlibMagic(Magic):
 
     def line_matplotlib(self, gui):
         """
-        Mosas
+        Matplotlib magic
+
+        You can set all backends you can with the IPython %Matplotlib
+        magic.
         """
-        from ipykernel.eventloops import enable_gui
-        from IPython.core.interactiveshell import InteractiveShell
-        
-        ipyshell = InteractiveShell()
-        ipyshell.enable_gui = enable_gui
-        ipyshell.enable_matplotlib(gui=gui)
+        gui, backend = self.kernel.ipyshell.enable_matplotlib(gui=gui)
+        self.kernel.mpl_gui = gui
 
 
 def register_magics(kernel):

--- a/spyder_kernels/ipdb/magics/matplotlib_magic.py
+++ b/spyder_kernels/ipdb/magics/matplotlib_magic.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2018- Spyder Kernels Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder_kernels/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+from metakernel import Magic
+
+
+class MatplotlibMagic(Magic):
+
+    def line_matplotlib(self, gui):
+        """
+        Mosas
+        """
+        from ipykernel.eventloops import enable_gui
+        from IPython.core.interactiveshell import InteractiveShell
+        
+        ipyshell = InteractiveShell()
+        ipyshell.enable_gui = enable_gui
+        ipyshell.enable_matplotlib(gui=gui)
+
+
+def register_magics(kernel):
+    kernel.register_magics(MatplotlibMagic)

--- a/spyder_kernels/ipdb/spyderpdb.py
+++ b/spyder_kernels/ipdb/spyderpdb.py
@@ -74,7 +74,10 @@ class SpyderPdb(pdb.Pdb):
         if not frame:
             return
 
-        kernel = get_ipython().kernel
+        try:
+            kernel = get_ipython().kernel
+        except AttributeError:
+            return
 
         # Get filename and line number of the current frame
         fname = self.canonic(frame.f_code.co_filename)
@@ -153,8 +156,11 @@ def _cmdloop(self):
 @monkeypatch_method(pdb.Pdb, 'Pdb')
 def reset(self):
     self._old_Pdb_reset()
-    kernel = get_ipython().kernel
-    kernel._register_pdb_session(self)
+    try:
+        kernel = get_ipython().kernel
+        kernel._register_pdb_session(self)
+    except AttributeError:
+        pass
 
 
 #XXX: notify spyder on any pdb command (is that good or too lazy? i.e. is more

--- a/spyder_kernels/ipdb/tests/test_ipdb_kernel.py
+++ b/spyder_kernels/ipdb/tests/test_ipdb_kernel.py
@@ -62,7 +62,7 @@ def test_available_magics(ipdb_kernel):
                   'jump', 'l', 'latex',  'list',
                   'll', 'load', 'long_list', 'ls', 'lsmagic', 'magic',
                   'matplotlib', 'n', 'next', 'p', 'pdef', 'pdoc',
-                  'pfile', 'pinfo', 'pinfo2', 'plot', 'pp', 'psource',
+                  'pfile', 'pinfo', 'pinfo2', 'pp', 'psource',
                   'python', 'q', 'quit', 'r', 'reload_magics', 'restart',
                   'return', 'retval', 'rv', 's',
                   'shell', 'source', 'step', 'tbreak', 'u', 'unalias',

--- a/spyder_kernels/ipdb/tests/test_ipdb_kernel.py
+++ b/spyder_kernels/ipdb/tests/test_ipdb_kernel.py
@@ -12,6 +12,7 @@
 """
 Tests for spyder_kernels.ipdb.kernel.py
 """
+
 # Standart library imports
 import os
 import os.path as osp

--- a/spyder_kernels/ipdb/tests/test_matplotlib.py
+++ b/spyder_kernels/ipdb/tests/test_matplotlib.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2018- Spyder Kernels Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder_kernels/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+from qtconsole.qtconsoleapp import JupyterQtConsoleApp
+import pytest
+
+
+SHELL_TIMEOUT = 20000
+
+
+@pytest.fixture
+def qtconsole(qtbot):
+    """Qtconsole fixture."""
+    # Create a console with the ipdb kernel
+    console = JupyterQtConsoleApp()
+    console.initialize(argv=['--kernel', 'ipdb_kernel'])
+
+    qtbot.addWidget(console.window)
+    console.window.confirm_exit = False
+    console.window.show()
+    return console
+
+
+def test_matplotlib_inline(qtconsole, qtbot):
+    """Test that %matplotlib inline is working."""
+    window = qtconsole.window
+    shell = window.active_frontend
+
+    # Wait until the console is fully up
+    qtbot.waitUntil(lambda: shell._prompt_html is not None,
+                    timeout=SHELL_TIMEOUT)
+
+    # Set inline backend
+    with qtbot.waitSignal(shell.executed):
+        shell.execute("%matplotlib inline")
+
+    # Make a plot
+    with qtbot.waitSignal(shell.executed):
+        shell.execute("import matplotlib.pyplot as plt; plt.plot(range(10))")
+
+    # Assert that there's a plot in the console
+    assert shell._control.toHtml().count('img src') == 1

--- a/spyder_kernels/ipdb/tests/test_matplotlib.py
+++ b/spyder_kernels/ipdb/tests/test_matplotlib.py
@@ -75,3 +75,7 @@ def test_matplotlib_qt(qtconsole, qtbot):
 
     # Assert the previous command returns the object
     assert 'PyQt5.QtWidgets.QApplication object' in shell._control.toPlainText()
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
Fixes #25.

TODO:

- [x] Add tests
- [x] Make inline plots be tight
- [x] Try to solve the metadata crash

---- 

Related work:

* Override default magics in MetaKernel: Calysto/metakernel#172
* Restore Python 2 compatibility in MetaKernel: Calysto/metakernel#173
* Fix wrong handling of metadata in MetaKernel display system: Calysto/metakernel#174