### PR TITLE
PR: Remove current working directory from sys.path before starting the console kernel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,10 @@ jobs:
           command: ./.circleci/install.sh
       - run:
           command: ./.circleci/run_tests.sh
-  python3.5:
+  python3.6:
     machine: true
     environment:
-      - PYTHON_VERSION: "3.5"
+      - PYTHON_VERSION: "3.6"
     steps:
       - checkout
       - run:
@@ -25,10 +25,10 @@ jobs:
           command: ./.circleci/install.sh
       - run:
           command: ./.circleci/run_tests.sh
-  python3.6:
+  python3.7:
     machine: true
     environment:
-      - PYTHON_VERSION: "3.6"
+      - PYTHON_VERSION: "3.7"
     steps:
       - checkout
       - run:
@@ -43,5 +43,5 @@ workflows:
   build_and_test:
     jobs:
       - python2.7
-      - python3.5
       - python3.6
+      - python3.7

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -27,6 +27,13 @@ def import_spydercustomize():
     parent = osp.dirname(here)
     customize_dir = osp.join(parent, 'customize')
 
+    # Remove current directory from sys.path to prevent kernel
+    # crashes when people name Python files or modules with
+    # the same name as standard library modules.
+    # See spyder-ide/spyder#8007
+    while '' in sys.path:
+        sys.path.remove('')
+
     # Import our customizations
     site.addsitedir(customize_dir)
     import spydercustomize
@@ -264,12 +271,15 @@ def main():
     __doc__ = ''
     __name__ = '__main__'
 
-    # Add current directory to sys.path (like for any standard Python interpreter
-    # executed in interactive mode):
-    sys.path.insert(0, '')
-
     # Import our customizations into the kernel
     import_spydercustomize()
+
+    # Remove current directory from sys.path to prevent kernel
+    # crashes when people name Python files or modules with
+    # the same name as standard library modules.
+    # See spyder-ide/spyder#8007
+    while '' in sys.path:
+        sys.path.remove('')
 
     # Fire up the kernel instance.
     from ipykernel.kernelapp import IPKernelApp

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -83,7 +83,7 @@ def test_magics(kernel):
                   'logstate', 'logstop', 'ls', 'lsmagic', 'macro', 'magic',
                   'matplotlib', 'mkdir', 'more', 'notebook', 'page',
                   'pastebin', 'pdb', 'pdef', 'pdoc', 'pfile', 'pinfo',
-                  'pinfo2', 'popd', 'pprint', 'precision', 'profile', 'prun',
+                  'pinfo2', 'popd', 'pprint', 'precision', 'prun',
                   'psearch', 'psource', 'pushd', 'pwd', 'pycat', 'pylab',
                   'qtconsole', 'quickref', 'recall', 'rehashx', 'reload_ext',
                   'rep', 'rerun', 'reset', 'reset_selective', 'rmdir',
@@ -107,8 +107,7 @@ def test_get_namespace_view(kernel):
     Test the namespace view of the kernel.
     """
     execute = kernel.do_execute('a = 1', True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     nsview = kernel.get_namespace_view()
     assert "'a':" in nsview
     assert "'type': 'int'" in nsview or "'type': u'int'" in nsview
@@ -122,8 +121,7 @@ def test_get_var_properties(kernel):
     Test the properties fo the variables in the namespace.
     """
     execute = kernel.do_execute('a = 1', True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     var_properties = kernel.get_var_properties()
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
@@ -151,8 +149,7 @@ def test_get_value(kernel):
     """Test getting the value of a variable."""
     name = 'a'
     execute = kernel.do_execute("a = 1", True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     # Check data type send
     kernel.get_value(name)
     log_text = get_log_text(kernel)
@@ -163,8 +160,7 @@ def test_set_value(kernel):
     """Test setting the value of a variable."""
     name = 'a'
     execute = kernel.do_execute('a = 0', True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     value = [cloudpickle.dumps(10, protocol=PICKLE_PROTOCOL)]
     PY2_frontend = False
     kernel.set_value(name, value, PY2_frontend)
@@ -180,8 +176,7 @@ def test_remove_value(kernel):
     """Test the removal of a variable."""
     name = 'a'
     execute = kernel.do_execute('a = 1', True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     var_properties = kernel.get_var_properties()
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
@@ -203,8 +198,7 @@ def test_copy_value(kernel):
     orig_name = 'a'
     new_name = 'b'
     execute = kernel.do_execute('a = 1', True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     var_properties = kernel.get_var_properties()
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
@@ -253,8 +247,7 @@ def test_save_namespace(kernel):
     """Test saving the namespace into filename."""
     namespace_file = osp.join(FILES_PATH, 'save_data.spydata')
     execute = kernel.do_execute('b = 1', True)
-    assert execute == {'execution_count': 0, 'payload': [], 'status': 'ok',
-                       'user_expressions': {}}
+
     kernel.save_namespace(namespace_file)
     assert osp.isfile(namespace_file)
     load_func = iofunctions.load_funcs['.spydata']
@@ -275,8 +268,8 @@ def test_is_defined(kernel):
 def test_get_doc(kernel):
     """Test to get object documentation dictionary."""
     objtxt = 'help'
-    assert "Define the builtin 'help'" in kernel.get_doc(objtxt)['docstring']
-
+    assert ("Define the builtin 'help'" in kernel.get_doc(objtxt)['docstring'] or
+            "Define the built-in 'help'" in kernel.get_doc(objtxt)['docstring'])
 
 def test_get_source(kernel):
     """Test to get object source."""


### PR DESCRIPTION
Fixes spyder-ide/spyder#8007

The cwd gets readded by IPython after the kernel starts.