### PR TITLE
PR: Exclude all tests from our tarballs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,4 @@ include AUTHORS.txt
 include CHANGELOG.md
 include LICENSE.txt
 include README.md
-recursive-include spyder_kernels/utils/tests *.mat *.spydata *.npz
+recursive-exclude * */tests/*.*

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     author_email="spyderlib@googlegroups.com",
     description="Jupyter kernels for Spyder's console",
     long_description="\n".join(DOCLINES[4:]),
-    packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
+    packages=find_packages(exclude=['docs']),
     install_requires=REQUIREMENTS,
     include_package_data=True,
     classifiers=['Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
I'm doing this because this package is not easy to test locally and we don't want other projects (like Debian) to ask us how to run our test suite in their CI servers.

They'll have to trust in our CI setup.