### PR TITLE
PR: runcell trigger post_execute before run_cell to end the run_cell pre_execute

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -713,7 +713,7 @@ def runcell(cellname, filename):
         return
 
     # Trigger `post_execute` to exit the additional pre-execution.
-    # See spyder #7310.
+    # See Spyder PR #7310.
     ipython_shell.events.trigger('post_execute')
 
     ipython_shell.run_cell(cell_code)

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -711,6 +711,11 @@ def runcell(cellname, filename):
                "Please use only through Spyder's Editor; "
                "shouldn't be called manually from the console")
         return
+
+    # Trigger `post_execute` to exit the additional pre-execution.
+    # See spyder #7310.
+    ipython_shell.events.trigger('post_execute')
+
     ipython_shell.run_cell(cell_code)
     del ipython_shell.cell_code
 


### PR DESCRIPTION
As discussed here:
https://github.com/spyder-ide/spyder/pull/7310

This is the simple fix:
```python
ipython_shell.events.trigger('post_execute')
ipython_shell.run_cell(cell_code)
```
Pull request coming to spyder-kernels.

The new runcell command runs the pre-execution trigger 3 times (and now closes twice) before every execution, but I don't notice any performance hit.