### PR TITLE
PR: Fix and improve saving of Spyder namespace with many types of objects

### DIFF
--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -317,39 +317,64 @@ def save_dictionary(data, filename):
             # Saving numpy arrays with np.save
             arr_fname = osp.splitext(filename)[0]
             for name in list(data.keys()):
-                if isinstance(data[name], np.ndarray) and data[name].size > 0:
-                    # Saving arrays at data root
-                    fname = __save_array(data[name], arr_fname,
-                                       len(saved_arrays))
-                    saved_arrays[(name, None)] = osp.basename(fname)
-                    data.pop(name)
-                elif isinstance(data[name], (list, dict)):
-                    # Saving arrays nested in lists or dictionaries
-                    if isinstance(data[name], list):
-                        iterator = enumerate(data[name])
-                    else:
-                        iterator = iter(list(data[name].items()))
-                    to_remove = []
-                    for index, value in iterator:
-                        if isinstance(value, np.ndarray) and value.size > 0:
-                            fname = __save_array(value, arr_fname,
-                                               len(saved_arrays))
-                            saved_arrays[(name, index)] = osp.basename(fname)
-                            to_remove.append(index)
-                    for index in sorted(to_remove, reverse=True):
-                        data[name].pop(index)
+                try:
+                    if isinstance(data[name],
+                                  np.ndarray) and data[name].size > 0:
+                        # Save arrays at data root
+                        fname = __save_array(data[name], arr_fname,
+                                             len(saved_arrays))
+                        saved_arrays[(name, None)] = osp.basename(fname)
+                        data.pop(name)
+                    elif isinstance(data[name], (list, dict)):
+                        # Save arrays nested in lists or dictionaries
+                        if isinstance(data[name], list):
+                            iterator = enumerate(data[name])
+                        else:
+                            iterator = iter(list(data[name].items()))
+                        to_remove = []
+                        for index, value in iterator:
+                            if isinstance(value,
+                                          np.ndarray) and value.size > 0:
+                                fname = __save_array(value, arr_fname,
+                                                     len(saved_arrays))
+                                saved_arrays[(name, index)] = (
+                                    osp.basename(fname))
+                                to_remove.append(index)
+                        for index in sorted(to_remove, reverse=True):
+                            data[name].pop(index)
+                except (RuntimeError, pickle.PicklingError, TypeError,
+                        AttributeError, IndexError):
+                    # If an array can't be saved with numpy for some reason,
+                    # leave the object intact and try to save it normally.
+                    pass
             if saved_arrays:
                 data['__saved_arrays__'] = saved_arrays
-        pickle_filename = osp.splitext(filename)[0]+'.pickle'
+
+        pickle_filename = osp.splitext(filename)[0] + '.pickle'
+        # Attempt to pickle everything.
+        # If pickling fails, iterate through to eliminate problem objs & retry.
         with open(pickle_filename, 'w+b') as fdesc:
-            pickle.dump(data, fdesc, 2)
+            try:
+                pickle.dump(data, fdesc, protocol=2)
+            except (pickle.PicklingError, AttributeError, TypeError,
+                    ImportError, IndexError):
+                data_filtered = {}
+                for obj_name, obj_value in data.items():
+                    try:
+                        pickle.dumps(obj_value, protocol=2)
+                    except Exception:
+                        skipped_keys.append(obj_name)
+                    else:
+                        data_filtered[obj_name] = obj_value
+                if not data_filtered:
+                    raise RuntimeError('No supported objects to save')
+                pickle.dump(data_filtered, fdesc, protocol=2)
+
         tar = tarfile.open(filename, "w")
         for fname in [pickle_filename]+[fn for fn in list(saved_arrays.values())]:
             tar.add(osp.basename(fname))
             os.remove(fname)
         tar.close()
-        if saved_arrays:
-            data.pop('__saved_arrays__')
     except (RuntimeError, pickle.PicklingError, TypeError) as error:
         error_message = to_text_string(error)
     else:

--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -290,16 +290,14 @@ def save_dictionary(data, filename):
     os.chdir(osp.dirname(filename))
     error_message = None
 
-    # Copy dictionary before modifying to fix #6689
     try:
-        data = copy.deepcopy(data)
-    except NotImplementedError:
+        # Copy dictionary before modifying it to fix #6689
         try:
+            data = copy.deepcopy(data)
+        # Fall back to non-deep copying for dicts with objs not supporting it
+        except NotImplementedError:
             data = copy.copy(data)
-        except Exception:
-            data = data
 
-    try:
         saved_arrays = {}
         if load_array is not None:
             # Saving numpy arrays with np.save
@@ -340,7 +338,8 @@ def save_dictionary(data, filename):
             data.pop('__saved_arrays__')
     except (RuntimeError, pickle.PicklingError, TypeError) as error:
         error_message = to_text_string(error)
-    os.chdir(old_cwd)
+    finally:
+        os.chdir(old_cwd)
     return error_message
 
 

--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -357,7 +357,7 @@ def save_dictionary(data, filename):
             try:
                 pickle.dump(data, fdesc, protocol=2)
             except (pickle.PicklingError, AttributeError, TypeError,
-                    ImportError, IndexError):
+                    ImportError, IndexError, RuntimeError):
                 data_filtered = {}
                 for obj_name, obj_value in data.items():
                     try:
@@ -381,6 +381,7 @@ def save_dictionary(data, filename):
         error_message = to_text_string(error)
     else:
         if skipped_keys:
+            skipped_keys.sort()
             error_message = ('Some objects could not be saved: '
                              + ', '.join(skipped_keys))
     finally:

--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -370,11 +370,13 @@ def save_dictionary(data, filename):
                     raise RuntimeError('No supported objects to save')
                 pickle.dump(data_filtered, fdesc, protocol=2)
 
-        tar = tarfile.open(filename, "w")
-        for fname in [pickle_filename]+[fn for fn in list(saved_arrays.values())]:
-            tar.add(osp.basename(fname))
-            os.remove(fname)
-        tar.close()
+        # Use PAX (POSIX.1-2001) format instead of default GNU.
+        # This improves interoperability and UTF-8/long variable name support.
+        with tarfile.open(filename, "w", format=tarfile.PAX_FORMAT) as tar:
+            for fname in ([pickle_filename]
+                          + [fn for fn in list(saved_arrays.values())]):
+                tar.add(osp.basename(fname))
+                os.remove(fname)
     except (RuntimeError, pickle.PicklingError, TypeError) as error:
         error_message = to_text_string(error)
     else:


### PR DESCRIPTION
As a compliment to #80 on the loading namespaces side, this PR implements a number of fixes to make saving them work much more reliably and robustly, and improve the user experience when problems occur. While it is independent of any changes in Spyder, it is complimented by spyder-ide/spyder#8636 which makes the UI text less confusing should some objects fail to be serialized.

In particular, as proposed in #75 , this PR:

* Fixes error messages not being printed by handling exceptions in the ``deepcopy()`` call properly
* Calls deepcopy on each individual value rather than the whole dict/namespace, to prevent falling back to normal ``copy`` or nothing at all for everything if one object cannot be deepcopied (or serialized entirely)
* Skips serializing anything that is a Python module as they cannot be serialized, and skips callables (functions/classes), as they can only be loaded if they already exist in the environment (thus it serves little purpose to do so, other than the prevent the rest of the environment from being loaded)
* If an object produces an error on attempted serialization, skips it and generate a popup warning listing the objects not serialized rather than refusing to save the entire session and forcing users to manually figure out and delete problem ones
* Doesn't try to fall back to a normal copy() if deepcopy() fails, since this essentially means pickle() will also fail barring exceptional circumstances and could lead to the user's environment being modified without warning
* Saves future ``spydata`` files in POSIX.1-2001-standard ("Pax") Tar format for lesser restrictions on and more consistent/cross platform file/variable names and metadata, as well as better interoperability and standards compliance; uses a context manager to ensure the Tar file is always closed properly. This is transparent to users and Spyder; the loading process is identical and any supported version of Python supports Pax equally to GNU.
* Ensures the current working directory is always reset properly even if an unhandled exception occurs

Further, it adds a number of test fixtures, simplifies many of the text functions and makes the test of saving the namespace much more comprehensive with a number of test cases and additional checks.

Fixes #75 