### PR TITLE
PR: fix traceback in python3

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -107,8 +107,10 @@ except ImportError:
     def execfile(filename, namespace):
         # Open a source file correctly, whatever its encoding is
         with open(filename, 'rb') as f:
-            exec(compile(f.read(), filename, 'exec'), namespace)
-
+            try:
+                exec(compile(f.read(), filename, 'exec'), namespace)
+            except:
+                get_ipython().showtraceback(running_compiled_code=True)
 
 #==============================================================================
 # Setting console encoding (otherwise Python does not recognize encoding)


### PR DESCRIPTION
Running a file where an error happens, I get a few unwanted lines in the traceback.
For example, with a file that says: 
```
raise RuntimeError
```
### Before:
![Screenshot 2019-05-17 at 15 13 12](https://user-images.githubusercontent.com/6740194/57933923-611a3800-78b6-11e9-8f0f-e3c20ae78788.png)
### After:
![Screenshot 2019-05-17 at 15 13 33](https://user-images.githubusercontent.com/6740194/57933928-637c9200-78b6-11e9-9323-16c09a6f8332.png)
