### PR TITLE
[Depends on #166] PR: Use unix signal to interrupt kernel

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -8,7 +8,6 @@
 In addition to the remote_call mechanism implemented in CommBase:
  - Implements _wait_reply, so blocking calls can be made.
 """
-import os
 import time
 import threading
 import pickle
@@ -24,7 +23,6 @@ class FrontendComm(CommBase):
         super(FrontendComm, self).__init__()
 
         # Comms
-        self._pid = os.getpid()
         self.kernel = kernel
         self.kernel.comm_manager.register_target(
             self._comm_name, self._comm_open)
@@ -67,6 +65,7 @@ class FrontendComm(CommBase):
         """
         A new comm is open!
         """
+        self.calling_comm_id = comm.comm_id
         self._register_comm(comm)
         self._set_pickle_protocol(msg['content']['data']['pickle_protocol'])
         self.remote_call()._set_pickle_protocol(pickle.HIGHEST_PROTOCOL)
@@ -74,7 +73,7 @@ class FrontendComm(CommBase):
     def _comm_close(self, msg):
         """Close comm."""
         comm_id = msg['content']['comm_id']
-        comm = self._comms[comm_id]
+        comm = self._comms[comm_id]['comm']
         # Pretend it is already closed to avoid problems when closing
         comm._closed = True
         del self._comms[comm_id]

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -311,6 +311,15 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
         self._pdb_breaking = False
 
     # --- Methods overriden by us
+    def set_continue(self):
+        """Stop only at breakpoints or when finished.
+
+        Reimplemented to avoid stepping out of debugging if there are no
+        breakpoints. We could add more later.
+        """
+        # Don't stop except at breakpoints or when finished
+        self._set_stopinfo(self.botframe, None, -1)
+
     def sigint_handler(self, signum, frame):
         """
         Handle a sigint signal. Break on the frame above this one.


### PR DESCRIPTION
This PR is built on top of PR #111  (and PR #112 but that can be removed, it is just easier for me.)
The problem I am trying to solve is the following:
 - If the kernel is executing something, it will not process incoming messages, because the ioloop is busy executing the code.
 - While debugging for example, this mean I can not set new breakpoints except if the debugging stopped (So no "Stop here, wherever 'here' is" possibility, or "oups, I forgot to put a breakopint here.")

ipykernel is using coroutines, which are not very compatible with threads. Therefore, another method must be used to do things "In parallel". The idea is to use unix signals (so no support for windows unfortunately). I don't want to interrupt anywhere in the `ioloop` code as it might cause problem, so the signal will abort unless:
 - `do_execute` is running
 - There is only one current call to `dispatch_shell` (just in case `do_execute` is calling `kernel.do_one_iteration()`)

An alternative would be to run the blocking code in another thread, but that would require modifying the ipykernel mechanisms.
