### PR TITLE
PR: Fix deprecated import

### DIFF
--- a/spyder_kernels/py3compat.py
+++ b/spyder_kernels/py3compat.py
@@ -76,7 +76,7 @@ else:
     from sys import maxsize
     import io
     import pickle
-    from collections import MutableMapping
+    from collections.abc import MutableMapping
     import _thread
     import reprlib
     import queue as Queue


### PR DESCRIPTION
Just a minor fix, but required for Python 3.8 support.