### PR TITLE
[WIP] PR: Add SymPy support

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -111,7 +111,8 @@ class SpyderKernel(IPythonKernel):
                     'is_data_frame': self._is_data_frame(value),
                     'is_series': self._is_series(value),
                     'array_shape': self._get_array_shape(value),
-                    'array_ndim': self._get_array_ndim(value)
+                    'array_ndim': self._get_array_ndim(value),
+                    'is_sympy': self._is_sympy(value),
                 }
 
             return repr(properties)
@@ -392,6 +393,15 @@ class SpyderKernel(IPythonKernel):
         try:
             from pandas import Series
             return isinstance(var, Series)
+        except:
+            return False
+
+
+    def _is_sympy(self, var):
+        """Return True if variable is a Series"""
+        try:
+            from sympy import Basic
+            return isinstance(var, Basic)
         except:
             return False
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -146,6 +146,7 @@ def test_get_var_properties(kernel):
     assert "'is_series': False" in var_properties
     assert "'array_shape': None" in var_properties
     assert "'array_ndim': None" in var_properties
+    assert "'is_sympy': False" in var_properties
 
 
 def test_send_spyder_msg(kernel):
@@ -201,6 +202,7 @@ def test_remove_value(kernel):
     assert "'is_series': False" in var_properties
     assert "'array_shape': None" in var_properties
     assert "'array_ndim': None" in var_properties
+    assert "'is_sympy': False" in var_properties
     kernel.remove_value(name)
     var_properties = kernel.get_var_properties()
     assert var_properties == '{}'
@@ -223,6 +225,7 @@ def test_copy_value(kernel):
     assert "'is_series': False" in var_properties
     assert "'array_shape': None" in var_properties
     assert "'array_ndim': None" in var_properties
+    assert "'is_sympy': False" in var_properties
     kernel.copy_value(orig_name, new_name)
     var_properties = kernel.get_var_properties()
     assert "'a'" in var_properties
@@ -236,6 +239,7 @@ def test_copy_value(kernel):
     assert "'is_series': False" in var_properties
     assert "'array_shape': None" in var_properties
     assert "'array_ndim': None" in var_properties
+    assert "'is_sympy': False" in var_properties
 
 
 def test_load_data(kernel):
@@ -254,6 +258,7 @@ def test_load_data(kernel):
     assert "'is_series': False" in var_properties
     assert "'array_shape': None" in var_properties
     assert "'array_ndim': None" in var_properties
+    assert "'is_sympy': False" in var_properties
 
 
 def test_save_namespace(kernel):
@@ -552,6 +557,25 @@ def test_matplotlib_inline(kernel):
         # Assert backend is inline
         assert 'inline' in value
 
+
+def test_sympy_detection(kernel):
+    """Test that the default backend for our kernels is 'inline'."""
+
+    execute = kernel.do_execute('from sympy import Symbol; a = Symbol("a")',
+                                True)
+
+    var_properties = kernel.get_var_properties()
+    assert "'a'" in var_properties
+    assert "'is_list': False" in var_properties
+    assert "'is_dict': False" in var_properties
+    assert "'len': None" in var_properties
+    assert "'is_array': False" in var_properties
+    assert "'is_image': False" in var_properties
+    assert "'is_data_frame': False" in var_properties
+    assert "'is_series': False" in var_properties
+    assert "'array_shape': None" in var_properties
+    assert "'array_ndim': None" in var_properties
+    assert "'is_sympy': True" in var_properties
 
 if __name__ == "__main__":
     pytest.main()

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -17,6 +17,7 @@ import datetime
 import numpy as np
 import pandas as pd
 import pytest
+import sympy
 
 # Local imports
 from spyder_kernels.py3compat import PY2
@@ -195,6 +196,17 @@ def test_set_display():
     # Long list of sets
     disp = '[' + ''.join('{0, 1, 2, 3, 4, ...}, '*10)[:-2] + ']'
     assert value_to_display([long_set] * 10) == disp[:70] + ' ...'
+
+
+def test_sympy_display():
+    """Tests for display of sets."""
+
+    # Simple symbol
+    assert value_to_display(sympy.Symbol('a')) == 'a'
+
+    # Simple subscript
+    assert value_to_display(sympy.bernoulli(sympy.Symbol('n'),
+                                            sympy.Symbol('x'))) == 'B \n n'
 
 
 def test_datetime_display():


### PR DESCRIPTION
I plan to add better SymPy support to Spyder. What I want to obtain is that SymPy expressions are "supported" and shown in the Variable explorer, ideally using SymPy pretty printing, e.g. 
```
        2    
 3   3⋅x    x
x  - ──── + ─
      2     2
```

As far as I can tell the only way to do this is to add support for it in spyder-kernels as these expressions will not be returned among the supported variables otherwise. Is this correct? Or is there a way to tell spyder-kernels to include even more types? Is this a good idea?

Furthermore, I do not really see a way to edit these expressions at the moment, I am more interested in them showing up in the Variable explorer. Hence, should I add a new type, displayable(?) here in addition to editable and picklable or should I just ignore editing attempts in Spyder?

As part of this, I am also planning to update the string truncation mechanism. Right now, a 3 x 3 matrix with zeros will print on three rows, but only as the total string length is below 70 characters. I plan to change that to that each row is evaluated and truncated at 70 characters, and rows above a certain threshold (10?) will be truncated in a sensible way. Hence, the introduction of the `truncated` flag with the purpose to say that the result is already truncated (for nparrays and SymPy expressions at least, more can be added). 

However, I have some problems testing spyder with my edited spyder-kernel. Any hints on how to obtain this?

(I also have some Spyder PRs upcoming with e.g. the ability to show pretty printed expressions in the Object explorer, which may be another way to obtain it, but as the SymPy expressions does not show in the Variable explorer by default it seems like a better idea to get them there first...)