### PR TITLE
Added .pickle files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ nppBackup/
 # Sphinx doc build dir
 _build/
 
+# Pickle results from tests
+*.pickle
+
 # Special dirs and files
 build/
 dist/


### PR DESCRIPTION
Running tests sometimes(?) generate these, so `git add .` used to add them...