### PR TITLE
PR: Add code completion to Pdb

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -76,3 +76,14 @@ class FrontendComm(CommBase):
         Send an async error back to the frontend to be displayed.
         """
         self.remote_call()._async_error(error_wrapper)
+
+    def _register_comm(self, comm):
+        """
+        Remove side effect ipykernel has.
+        """
+        def handle_msg(msg):
+            """Handle a comm_msg message"""
+            if comm._msg_callback:
+                comm._msg_callback(msg)
+        comm.handle_msg = handle_msg
+        super(FrontendComm, self)._register_comm(comm)

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -234,6 +234,8 @@ class SpyderKernel(IPythonKernel):
     def do_complete(self, code, cursor_pos):
         """
         Call PdB complete if we are debugging.
+
+        Public method of ipykernel overwritten for debugging.
         """
         if cursor_pos is None:
             cursor_pos = len(code)
@@ -249,7 +251,7 @@ class SpyderKernel(IPythonKernel):
             begidx = cursor_pos - len(text) - stripped
             endidx = cursor_pos - stripped
             if begidx > 0:
-                cmd, args, foo = self._pdb_obj.parseline(line)
+                cmd, args, _ = self._pdb_obj.parseline(line)
                 if cmd == '':
                     compfunc = self._pdb_obj.completedefault
                 else:

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -25,6 +25,7 @@ import pytest
 from spyder_kernels.py3compat import PY3, to_text_string
 from spyder_kernels.utils.iofuncs import iofunctions
 from spyder_kernels.utils.test_utils import get_kernel, get_log_text
+from spyder_kernels.customize.spydercustomize import SpyderPdb
 
 
 # =============================================================================
@@ -552,6 +553,23 @@ def test_matplotlib_inline(kernel):
 
         # Assert backend is inline
         assert 'inline' in value
+
+def test_do_complete(kernel):
+    """
+    Check do complete works in normal and debugging mode.
+    """
+    kernel.do_execute('abba = 1', True)
+    assert kernel.get_value('abba') == 1
+    match = kernel.do_complete('ab', 2)
+    assert 'abba' in match['matches']
+
+    # test pdb
+    pdb_obj = SpyderPdb()
+    pdb_obj.curframe = True
+    pdb_obj.completenames = lambda *ignore: ['baba']
+    kernel._pdb_obj = pdb_obj
+    match = kernel.do_complete('ba', 2)
+    assert 'baba' in match['matches']
 
 
 if __name__ == "__main__":

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -423,6 +423,21 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
         except (CommError, TimeoutError):
             logger.debug("Could not send Pdb state to the frontend.")
 
+    def completenames(self, text, line, begidx, endidx):
+        """
+        Try to complete with command names, otherwise goes to default.
+        """
+        matched_names = super(SpyderPdb, self).completenames(
+            text, line, begidx, endidx)
+        matched_default = self.completedefault(text, line, begidx, endidx)
+        return matched_names + matched_default
+
+    def completedefault(self, text, line, begidx, endidx):
+        """
+        Default completion.
+        """
+        return self._complete_expression(text, line, begidx, endidx)
+
 
 pdb.Pdb = SpyderPdb
 

--- a/spyder_kernels/py3compat.py
+++ b/spyder_kernels/py3compat.py
@@ -293,5 +293,14 @@ if PY2:
 else:
     TimeoutError = TimeoutError
 
+if PY2:
+    import re
+    import tokenize
+    def isidentifier(string):
+        return re.match(tokenize.Name + r'\Z', string) is not None
+else:
+    def isidentifier(string):
+        return string.isidentifier()
+
 if __name__ == '__main__':
     pass

--- a/spyder_kernels/py3compat.py
+++ b/spyder_kernels/py3compat.py
@@ -297,9 +297,11 @@ if PY2:
     import re
     import tokenize
     def isidentifier(string):
+        """Check if string can be a variable name."""
         return re.match(tokenize.Name + r'\Z', string) is not None
 else:
     def isidentifier(string):
+        """Check if string can be a variable name."""
         return string.isidentifier()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds call to the pdb autocomplete mechanism when the kernel is debugging.

This depends on my other PR because the corresponding spyder PR, https://github.com/spyder-ide/spyder/pull/9940, depends on the corresponding other PR as well.

The main reason for the dependence is that the kernel needs to be interrupted to receive the interruption request.