### PR TITLE
PR: Add a way to change foreground color of Sympy repr's

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -55,7 +55,7 @@ class SpyderKernel(IPythonKernel):
             'get_namespace_view': self.get_namespace_view,
             'set_namespace_view_settings': self.set_namespace_view_settings,
             'get_var_properties': self.get_var_properties,
-            'set_equations_color': self.set_equations_color
+            'set_sympy_forecolor': self.set_sympy_forecolor
             }
         for call_id in handlers:
             self.frontend_comm.register_call_handler(
@@ -486,6 +486,18 @@ class SpyderKernel(IPythonKernel):
         if self._mpl_backend_error is not None:
             print(self._mpl_backend_error)  # spyder: test-skip
 
+    def set_sympy_forecolor(self, background_color='dark'):
+        """Set SymPy forecolor depending on console background."""
+        if os.environ.get('SPY_SYMPY_O') == 'True':
+            try:
+                from sympy import init_printing
+                if background_color == 'dark':
+                    init_printing(forecolor='White')
+                elif background_color == 'light':
+                    init_printing(forecolor='Black')
+            except Exception:
+                pass
+
     # --- Others
     def _load_autoreload_magic(self):
         """Load %autoreload magic."""
@@ -508,14 +520,3 @@ class SpyderKernel(IPythonKernel):
                 get_ipython().run_line_magic('reload_ext', 'wurlitzer')
             except Exception:
                 pass
-
-    def set_equations_color(self, background_color='dark'):
-        """Set sympy equations_color depending on background."""
-        try:
-            from sympy import init_printing
-            if background_color == 'dark':
-                init_printing(forecolor='White')
-            elif background_color == 'light':
-                init_printing(forecolor='Black')
-        except:
-            pass

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -55,6 +55,7 @@ class SpyderKernel(IPythonKernel):
             'get_namespace_view': self.get_namespace_view,
             'set_namespace_view_settings': self.set_namespace_view_settings,
             'get_var_properties': self.get_var_properties,
+            'set_equations_color': self.set_equations_color
             }
         for call_id in handlers:
             self.frontend_comm.register_call_handler(
@@ -507,3 +508,12 @@ class SpyderKernel(IPythonKernel):
                 get_ipython().run_line_magic('reload_ext', 'wurlitzer')
             except Exception:
                 pass
+    def set_equations_color(self, background_color):
+        try:
+            from sympy import init_printing
+            if background_color=="dark":
+                init_printing(forecolor='White')
+            else:
+                init_printing(forecolor='Black')
+        except:
+            pass

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -491,10 +491,11 @@ class SpyderKernel(IPythonKernel):
         if os.environ.get('SPY_SYMPY_O') == 'True':
             try:
                 from sympy import init_printing
+                from IPython.core.getipython import get_ipython
                 if background_color == 'dark':
-                    init_printing(forecolor='White')
+                    init_printing(forecolor='White', ip=get_ipython())
                 elif background_color == 'light':
-                    init_printing(forecolor='Black')
+                    init_printing(forecolor='Black', ip=get_ipython())
             except Exception:
                 pass
 

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -508,12 +508,14 @@ class SpyderKernel(IPythonKernel):
                 get_ipython().run_line_magic('reload_ext', 'wurlitzer')
             except Exception:
                 pass
-    def set_equations_color(self, background_color):
+
+    def set_equations_color(self, background_color='dark'):
+        """Set sympy equations_color depending on background."""
         try:
             from sympy import init_printing
-            if background_color=="dark":
+            if background_color == 'dark':
                 init_printing(forecolor='White')
-            else:
+            elif background_color == 'light':
                 init_printing(forecolor='Black')
         except:
             pass


### PR DESCRIPTION
Added method for setting the colors of the sympy equations depending on the background color.

![Screen Shot 2019-08-27 at 10 25 26 AM](https://user-images.githubusercontent.com/18587879/63784935-0f217f00-c8b5-11e9-8baf-98f85f49ee53.png)

Issue Spyder-ide/spyder#3798