### PR TITLE
PR: Use IPython safe_execfile to execute files and clean tracebacks

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -368,7 +368,7 @@ def test_runfile(tmpdir):
         client.get_shell_msg(block=True, timeout=TIMEOUT)
 
         # Write defined variable code to a file
-        code = u"result = 'hello world'"
+        code = u"result = 'hello world'; error # make an error"
         d = tmpdir.join("defined-test.py")
         d.write(code)
 
@@ -382,7 +382,7 @@ def test_runfile(tmpdir):
         u = tmpdir.join("undefined-test.py")
         u.write(code)
 
-        # Run code file `d` to define `result`
+        # Run code file `d` to define `result` even after error
         client.execute("runfile(r'{}', current_namespace=False)"
                        .format(to_text_string(d)))
         client.get_shell_msg(block=True, timeout=TIMEOUT)

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -382,7 +382,7 @@ def test_runfile(tmpdir):
         u = tmpdir.join("undefined-test.py")
         u.write(code)
 
-        # Run code file `d` to define `result` even after error
+        # Run code file `d` to define `result` even after an error
         client.execute("runfile(r'{}', current_namespace=False)"
                        .format(to_text_string(d)))
         client.get_shell_msg(block=True, timeout=TIMEOUT)

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -887,8 +887,7 @@ def runfile(filename, args=None, wdir=None, namespace=None,
         with io.open(filename, encoding='utf-8') as f:
             ipython_shell.run_cell_magic('cython', '', f.read())
     else:
-        ipython_shell.safe_execfile(filename, namespace,
-                                    exit_ignore=True)
+        ipython_shell.safe_execfile(filename, namespace)
 
     ipython_shell.user_ns.update(namespace)
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -887,7 +887,8 @@ def runfile(filename, args=None, wdir=None, namespace=None,
         with io.open(filename, encoding='utf-8') as f:
             ipython_shell.run_cell_magic('cython', '', f.read())
     else:
-        execfile(filename, namespace)
+        ipython_shell.safe_execfile(filename, namespace,
+                                    exit_ignore=True)
 
     ipython_shell.user_ns.update(namespace)
 


### PR DESCRIPTION
This change uses IPython's `safe_execfile` function to execute files in `runfile`. 

This `safe_execfile` catches and prints the file error allowing execution of the `runfile` function to continue after an error in the file. This allows us to still load the namespace of the file into the global namespace after an error. 

It also has the nice side effect of giving clean error tracebacks. @impact27, will #134 be necessary after this change? 

Before:
```python traceback
Traceback (most recent call last):

  File "<ipython-input-1-664d90654f60>", line 1, in <module>
    runfile('/home/bcolsen/Documents/python/jv_stat_bing/plot_data_set.py', wdir='/home/bcolsen/Documents/python/jv_stat_bing')

  File "/home/bcolsen/anaconda3/lib/python3.6/site-packages/spyder_kernels-1.5.0.dev0-py3.6.egg/spyder_kernels/customize/spydercustomize.py", line 890, in runfile
    execfile(filename, namespace)

  File "/home/bcolsen/anaconda3/lib/python3.6/site-packages/spyder_kernels-1.5.0.dev0-py3.6.egg/spyder_kernels/customize/spydercustomize.py", line 116, in execfile
    exec(compile(f.read(), filename, 'exec'), namespace)

  File "/home/bcolsen/Documents/python/jv_stat_bing/plot_data_set.py", line 500, in <module>
    yo

NameError: name 'yo' is not defined
```

After
```python traceback
Traceback (most recent call last):

  File "/home/bcolsen/Documents/python/jv_stat_bing/plot_data_set.py", line 500, in <module>
    yo

NameError: name 'yo' is not defined
```

The default to cleanly exit without an error with `sys.exit()` making the work flow in https://github.com/spyder-ide/spyder/issues/8100 more clean. 

This might affect other areas as well.


