### PR TITLE
PR: Solve error with exit command not being defined in the debugger

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -483,7 +483,7 @@ def user_return(self, frame, return_value):
 @monkeypatch_method(pdb.Pdb, 'Pdb')
 def interaction(self, frame, traceback):
     if frame is not None and "spydercustomize.py" in frame.f_code.co_filename:
-        self.run('exit')
+        self.onecmd('exit')
     else:
         self.setup(frame, traceback)
         if self.send_initial_notification:


### PR DESCRIPTION
Solve a problem where a NameError is raised while debugging.

To reproduce:
1. Start debugging a file (For example, a single print statment in a file)
2. Type `n` until debugging finishes
3. 
```python-traceback
Traceback (most recent call last):

  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/bdb.py", line 92, in trace_dispatch
    return self.dispatch_return(frame, arg)

  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/bdb.py", line 151, in dispatch_return
    self.user_return(frame, arg)

  File "/Users/quentinpeter/pyscripts/spyder-kernels/spyder_kernels/customize/spydercustomize.py", line 480, in user_return
    self._old_Pdb_user_return(frame, return_value)

  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/pdb.py", line 293, in user_return
    self.interaction(frame, None)

  File "/Users/quentinpeter/pyscripts/spyder-kernels/spyder_kernels/customize/spydercustomize.py", line 486, in interaction
    self.run('exit')

  File "/usr/local/Cellar/python/3.7.3/Frameworks/Python.framework/Versions/3.7/lib/python3.7/bdb.py", line 585, in run
    exec(cmd, globals, locals)

  File "<string>", line 1, in <module>

NameError: name 'exit' is not defined
```