### PR TITLE
PR: Allow Pdb to run multiline statments

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -454,8 +454,16 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
                 sys.stdin = save_stdin
                 sys.displayhook = save_displayhook
         except:
-            exc_info = sys.exc_info()[:2]
-            self.error(traceback.format_exception_only(*exc_info)[-1].strip())
+            if PY2:
+                t, v = sys.exc_info()[:2]
+                if type(t) == type(''):
+                    exc_type_name = t
+                else: exc_type_name = t.__name__
+                print >>self.stdout, '***', exc_type_name + ':', v
+            else:
+                exc_info = sys.exc_info()[:2]
+                self.error(
+                    traceback.format_exception_only(*exc_info)[-1].strip())
 
 
 pdb.Pdb = SpyderPdb


### PR DESCRIPTION
Reimplement Pdb.default to allow running multiline statement.
Before, pasting
```
print(0)
print(1)
```
in the debugger would give:
`*** SyntaxError: multiple statements found while compiling a single statement`
With this PR, it gives:
```
0
1
```