### PR TITLE
Process pending messages and matplotlib events while waiting for input.

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -529,13 +529,11 @@ class SpyderKernel(IPythonKernel):
                 pass
 
     def _input_request(self, prompt, ident, parent, password=False):
-        """Send an input request to the frontend and wait for the reply."""
-        # matplotlib needs to be imported after app.launch_new_instance()
-        try:
-            from matplotlib._pylab_helpers import Gcf
-        except ImportError:
-            Gcf = None
+        """Send an input request to the frontend and wait for the reply.
 
+        This function can be removed if
+        https://github.com/ipython/ipykernel/pull/439 is merged
+        """
         # Flush output before making the request.
         sys.stderr.flush()
         sys.stdout.flush()
@@ -553,6 +551,34 @@ class SpyderKernel(IPythonKernel):
         content = json_clean(dict(prompt=prompt, password=password))
         self.session.send(self.stdin_socket, u'input_request', content, parent,
                           ident=ident)
+        # Await a response.
+        reply = self._wait_input_request_reply()
+
+        try:
+            value = py3compat.unicode_to_str(reply['content']['value'])
+        except:
+            self.log.error("Bad input_reply: %s", parent)
+            value = ''
+        if value == '\x04':
+            # EOF
+            raise EOFError
+        return value
+
+    def _wait_input_request_reply(self):
+        """Wait for an input request reply.
+
+        Raises
+        ------
+        KeyboardInterrupt if a keyboard interrupt is recieved.
+        """
+        # matplotlib needs to be imported after app.launch_new_instance()
+        if 'matplotlib.pyplot' in sys.modules:
+            def flush_matplotlib():
+                import matplotlib.pyplot as plt
+                if plt.get_fignums():
+                    plt.gcf().canvas.flush_events()
+        else:
+            flush_matplotlib = None
 
         # Await a response.
         reply = None
@@ -565,20 +591,13 @@ class SpyderKernel(IPythonKernel):
                     # Allow comms and other messages to be processed
                     self.do_one_iteration()
                     # Allow matplotlib figures with e.g. qt5 to update
-                    if Gcf and Gcf.get_active():
-                        Gcf.get_active().canvas.flush_events()
+                    if flush_matplotlib:
+                        flush_matplotlib()
 
             except Exception:
                 self.log.warning("Invalid Message:", exc_info=True)
             except KeyboardInterrupt:
                 # re-raise KeyboardInterrupt, to truncate traceback
                 raise KeyboardInterrupt
-        try:
-            value = py3compat.unicode_to_str(reply['content']['value'])
-        except:
-            self.log.error("Bad input_reply: %s", parent)
-            value = ''
-        if value == '\x04':
-            # EOF
-            raise EOFError
-        return value
+
+        return reply


### PR DESCRIPTION
See PR https://github.com/ipython/ipykernel/pull/438

Adding this PR to ipykernel looks complicated as this would cause messages being potentially processed out of order. Here, we control the frontend (In most cases), so processing the messages should be safer.

The potential problems are that a message like 'execute_request' might be recieved by the kernel while debugging or waiting for a general input. The Spyder frontend doesn't do that (as far as I know) but another frontend might.

`spyder-kernels` is already exposed to this problem as calling `do_one_iteration` is how the comms can do blocking calls. It is also used in my 'complete during debugging' PR.

I think most users of `spyder-kernels` will use it with spyder. So I would rather support seeing plots while debugging than not risk a bug popping up if someone uses another frontend with spyder kernels.

A better implementation could be done but probably not before spyder4:

Pdb should make some kind of special request (This could be generalized to other command line system). What I would see is:
 - The input request is sent to a single client (If I am not mistaken). Therefore only messages from this client should be processed while waiting for an input. (Are messages sent from different clients supposed to be processed in order, or just messages from a single client?)
 - The input request should contain some kind of field that notifies the frontend that this is a special input request, so the frontend could do act accordingly. For example, it would know it is ok to send messages as they could be processed. (Such as comm, complete_request, ...)
 - The kernel would process only messages that the frontend sends with this special value in the header. If the frontend sends a non-special message the processing would stop. 
