### PR TITLE
PR: Don't demand that a file exists in Pdb

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -927,6 +927,11 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         filename = get_current_file_name()
         if filename is None:
             return
+    else:
+        # get_debugger replaces \\ by / so we must undo that here
+        # Otherwise code caching doesn't work
+        if os.name == 'nt':
+            filename = filename.replace('/', '\\')
 
     try:
         filename = filename.decode('utf-8')
@@ -1027,6 +1032,11 @@ def runcell(cellname, filename=None):
         filename = get_current_file_name()
         if filename is None:
             return
+    else:
+        # get_debugger replaces \\ by / so we must undo that here
+        # Otherwise code caching doesn't work
+        if os.name == 'nt':
+            filename = filename.replace('/', '\\')
     try:
         filename = filename.decode('utf-8')
     except (UnicodeError, TypeError, AttributeError):

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -382,8 +382,7 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
             # Fixes issue 4681
             if (self.continue_if_has_breakpoints and
                     breaks and
-                    lineno < breaks[0] and
-                    osp.isfile(fname)):
+                    lineno < breaks[0]):
                 try:
                     get_ipython().kernel.pdb_continue()
                 except (CommError, TimeoutError):
@@ -409,8 +408,7 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
         # Set step of the current frame (if any)
         step = {}
         if isinstance(fname, basestring) and isinstance(lineno, int):
-            if osp.isfile(fname):
-                step = dict(fname=fname, lineno=lineno)
+            step = dict(fname=fname, lineno=lineno)
 
         # Publish Pdb state so we can update the Variable Explorer
         # and the Editor on the Spyder side


### PR DESCRIPTION
Now that we can debug files that don't exist locally, the calls to `os.path.isfile` must be removed.