### PR TITLE
PR: Create a Comm socket

### DIFF
--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -151,14 +151,6 @@ class CommBase(object):
             'remote_call', self._handle_remote_call)
         self._register_message_handler(
             'remote_call_reply', self._handle_remote_call_reply)
-
-        # Dummy functions for testing and to trigger side effects such as
-        # an interruption or waiting for a reply.
-        def pong_back():
-            self.remote_call(self.calling_comm_id).pong()
-
-        self.register_call_handler('ping', pong_back)
-        self.register_call_handler('pong', lambda: None)
         self.register_call_handler('_set_pickle_protocol',
                                    self._set_pickle_protocol)
 

--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -110,7 +110,7 @@ class CommsErrorWrapper():
         return str(self.error)
 
     def __repr__(self):
-        """Get string representation."""
+        """Get repr."""
         return repr(self.error)
 
 

--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -106,11 +106,11 @@ class CommsErrorWrapper():
             print(line, file=file)
 
     def __str__(self):
-        """Get string representation"""
+        """Get string representation."""
         return str(self.error)
 
     def __repr__(self):
-        """Get string representation"""
+        """Get string representation."""
         return repr(self.error)
 
 
@@ -155,7 +155,7 @@ class CommBase(object):
                                    self._set_pickle_protocol)
 
     def get_comm_id_list(self, comm_id=None):
-        """Get a list of comms id"""
+        """Get a list of comms id."""
         if comm_id is None:
             id_list = list(self._comms.keys())
         else:

--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -162,13 +162,17 @@ class CommBase(object):
         self.register_call_handler('_set_pickle_protocol',
                                    self._set_pickle_protocol)
 
-    def close(self, comm_id=None):
-        """Close the comm and notify the other side."""
+    def get_comm_id_list(self, comm_id=None):
+        """Get a list of comms id"""
         if comm_id is None:
-            # close all the comms
             id_list = list(self._comms.keys())
         else:
             id_list = [comm_id]
+        return id_list
+
+    def close(self, comm_id=None):
+        """Close the comm and notify the other side."""
+        id_list = self.get_comm_id_list(comm_id)
 
         for comm_id in id_list:
             self._comms[comm_id]['comm'].close()
@@ -187,11 +191,7 @@ class CommBase(object):
         The check is made with _set_pickle_protocol as this is the first call
         made. If comm_id is not specified, check all comms.
         """
-        if comm_id is None:
-            # close all the comms
-            id_list = list(self._comms.keys())
-        else:
-            id_list = [comm_id]
+        id_list = self.get_comm_id_list(comm_id)
         if len(id_list) == 0:
             return False
         return all([self._comms[cid]['status'] == 'ready' for cid in id_list])
@@ -238,11 +238,7 @@ class CommBase(object):
         """
         if not self.is_open(comm_id):
             raise CommError("The comm is not connected.")
-        if comm_id is None:
-            # send to all the comms
-            id_list = list(self._comms.keys())
-        else:
-            id_list = [comm_id]
+        id_list = self.get_comm_id_list(comm_id)
         for comm_id in id_list:
             msg_dict = {
                 'spyder_msg_type': spyder_msg_type,
@@ -394,13 +390,17 @@ class CommBase(object):
         if blocking or callback is not None:
             self._reply_waitlist[call_id] = blocking, callback
 
-    def _get_call_return_value(self, call_dict):
+    def _get_call_return_value(self, call_dict, call_data, comm_id):
         """
-        A remote call has just been sent.
+        Send a remote call and return the reply.
 
         If settings['blocking'] == True, this will wait for a reply and return
         the replied value.
         """
+        self._send_message(
+            'remote_call', content=call_dict, data=call_data,
+            comm_id=comm_id)
+
         settings = call_dict['settings']
 
         blocking = 'blocking' in settings and settings['blocking']
@@ -543,7 +543,5 @@ class RemoteCall():
             logger.debug("Call to unconnected comm: %s" % self._name)
             return
         self._comms_wrapper._register_call(call_dict, self._callback)
-        self._comms_wrapper._send_message(
-            'remote_call', content=call_dict, data=call_data,
-            comm_id=self._comm_id)
-        return self._comms_wrapper._get_call_return_value(call_dict)
+        return self._comms_wrapper._get_call_return_value(
+            call_dict, call_data, self._comm_id)

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -69,6 +69,7 @@ class FrontendComm(CommBase):
             # Create an event loop to handle some messages
             ioloop.IOLoop().initialize()
         while True:
+            out_stream = self.kernel.shell_streams[0]
             try:
                 ident, msg = self.kernel.session.recv(self.comm_socket, 0)
             except Exception:
@@ -81,13 +82,15 @@ class FrontendComm(CommBase):
             else:
                 try:
                     # shell_streams[0] handles replies
-                    handler(self.kernel.shell_streams[0], ident, msg)
+                    handler(out_stream, ident, msg)
                 except Exception:
                     self.kernel.log.error("Exception in message handler:",
                                           exc_info=True)
 
             sys.stdout.flush()
             sys.stderr.flush()
+            # flush to ensure reply is sent
+            out_stream.flush(zmq.POLLOUT)
 
     def remote_call(self, comm_id=None, blocking=False, callback=None):
         """Get a handler for remote calls."""

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -67,16 +67,17 @@ class FrontendComm(CommBase):
 
             # patch parent.close
             self.comm_thread_close = threading.Event()
-            super_close = self.kernel.parent.close
+            if not PY2:
+                super_close = self.kernel.parent.close
 
-            def close():
-                """Close comm_socket_thread."""
-                self.comm_thread_close.set()
-                context.term()
-                self.comm_socket_thread.join()
-                super_close()
+                def close():
+                    """Close comm_socket_thread."""
+                    self.comm_thread_close.set()
+                    context.term()
+                    self.comm_socket_thread.join()
+                    super_close()
 
-            self.kernel.parent.close = close
+                self.kernel.parent.close = close
 
     def poll_thread(self):
         """Recieve messages from comm socket"""

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -126,7 +126,8 @@ class FrontendComm(CommBase):
         """Wait until the frontend replies to a request."""
         if call_id in self._reply_inbox:
             return
-
+        if threading.get_ident() == self.comm_socket_thread.ident:
+            raise RuntimeError("Can't make blocking calls from comm thread.")
         t_start = time.time()
         while call_id not in self._reply_inbox:
             if time.time() > t_start + timeout:

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -33,7 +33,7 @@ def get_port():
 
 
 class FrontendComm(CommBase):
-    """Mixin to implement the spyder_shell_api"""
+    """Mixin to implement the spyder_shell_api."""
 
     def __init__(self, kernel):
         super(FrontendComm, self).__init__()
@@ -83,7 +83,7 @@ class FrontendComm(CommBase):
                 self.kernel.parent.close = close
 
     def poll_thread(self):
-        """Recieve messages from comm socket"""
+        """Recieve messages from comm socket."""
         if not PY2:
             # Create an event loop to handle some messages
             ioloop.IOLoop().initialize()

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -22,6 +22,7 @@ from spyder_kernels.py3compat import TimeoutError, PY2
 
 
 def get_port():
+    """Find a free port on the local machine."""
     sock = socket.socket()
     # struct.pack('ii', (0,0)) is 8 null bytes
     sock.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER, b'\0' * 8)

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -57,25 +57,25 @@ class FrontendComm(CommBase):
             self.comm_port = self.kernel.parent._bind_socket(
                 self.comm_socket, self.comm_port)
             if hasattr(zmq, 'ROUTER_HANDOVER'):
-                # set router-handover to workaround zeromq reconnect problems
-                # in certain rare circumstances
-                # see ipython/ipykernel#270 and zeromq/libzmq#2892
+                # Set router-handover to workaround zeromq reconnect problems
+                # in certain rare circumstances.
+                # See ipython/ipykernel#270 and zeromq/libzmq#2892
                 self.comm_socket.router_handover = 1
 
             self.comm_thread_close = threading.Event()
             self.comm_socket_thread = threading.Thread(target=self.poll_thread)
             self.comm_socket_thread.start()
 
-            # patch parent.close
+            # Patch parent.close . This function only exists in Python 3.
             if not PY2:
-                super_close = self.kernel.parent.close
+                parent_close = self.kernel.parent.close
 
                 def close():
                     """Close comm_socket_thread."""
                     self.comm_thread_close.set()
                     context.term()
                     self.comm_socket_thread.join()
-                    super_close()
+                    parent_close()
 
                 self.kernel.parent.close = close
 
@@ -118,7 +118,7 @@ class FrontendComm(CommBase):
 
         sys.stdout.flush()
         sys.stderr.flush()
-        # flush to ensure reply is sent
+        # Flush to ensure reply is sent
         if out_stream:
             out_stream.flush(zmq.POLLOUT)
 

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -45,6 +45,8 @@ class FrontendComm(CommBase):
         if not PY2:
             self._main_thread_id = threading.get_ident()
 
+        self.comm_port = None
+
         if self.kernel.parent:
             # self.kernel.parent is IPKernelApp unless we are in tests
             # Create a new socket

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -43,9 +43,6 @@ class FrontendComm(CommBase):
         self.kernel.comm_manager.register_target(
             self._comm_name, self._comm_open)
 
-        if not PY2:
-            self._main_thread_id = threading.get_ident()
-
         self.comm_port = None
 
         if self.kernel.parent:
@@ -139,7 +136,7 @@ class FrontendComm(CommBase):
                 raise TimeoutError(
                     "Timeout while waiting for '{}' reply".format(
                         call_name))
-            if threading.get_ident() == self.comm_socket_thread.ident:
+            if threading.current_thread() is self.comm_socket_thread:
                 # Wait for a reply on the comm channel.
                 self.poll_one()
             else:

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -85,25 +85,14 @@ class FrontendComm(CommBase):
         if call_id in self._reply_inbox:
             return
 
-        # There is no get_ident in Py2
-        if not PY2 and self._main_thread_id != threading.get_ident():
-            # We can't call kernel.do_one_iteration from this thread.
-            # And we have no reason to think the main thread is not busy.
-            raise CommError(
-                "Can't make blocking calls from non-main threads.")
-
         t_start = time.time()
         while call_id not in self._reply_inbox:
             if time.time() > t_start + timeout:
                 raise TimeoutError(
                     "Timeout while waiting for '{}' reply".format(
                         call_name))
-            priority = 0
-            while priority is not None:
-                priority = self.kernel.do_one_iteration()
-                if priority is not None:
-                    # For Python2
-                    priority = priority.result()
+            # Wait 10ms for a reply
+            time.sleep(0.01)
 
     def _comm_open(self, comm, msg):
         """

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -96,6 +96,9 @@ class FrontendComm(CommBase):
                 self.kernel.log.warning("Invalid Message:", exc_info=True)
             msg_type = msg['header']['msg_type']
 
+            if msg_type == 'shutdown_request':
+                return
+
             handler = self.kernel.shell_handlers.get(msg_type, None)
             if handler is None:
                 self.kernel.log.warning("Unknown message type: %r", msg_type)

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -64,11 +64,11 @@ class FrontendComm(CommBase):
                 # see ipython/ipykernel#270 and zeromq/libzmq#2892
                 self.comm_socket.router_handover = 1
 
+            self.comm_thread_close = threading.Event()
             self.comm_socket_thread = threading.Thread(target=self.poll_thread)
             self.comm_socket_thread.start()
 
             # patch parent.close
-            self.comm_thread_close = threading.Event()
             if not PY2:
                 super_close = self.kernel.parent.close
 

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -98,6 +98,7 @@ class FrontendComm(CommBase):
             ident, msg = self.kernel.session.recv(self.comm_socket, 0)
         except Exception:
             self.kernel.log.warning("Invalid Message:", exc_info=True)
+            return
         msg_type = msg['header']['msg_type']
 
         if msg_type == 'shutdown_request':
@@ -113,6 +114,7 @@ class FrontendComm(CommBase):
             except Exception:
                 self.kernel.log.error("Exception in message handler:",
                                       exc_info=True)
+                return
 
         sys.stdout.flush()
         sys.stderr.flush()

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -312,6 +312,15 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
         self._pdb_breaking = False
 
     # --- Methods overriden by us
+    def set_continue(self):
+        """Stop only at breakpoints or when finished.
+
+        Reimplemented to avoid stepping out of debugging if there are no
+        breakpoints. We could add more later.
+        """
+        # Don't stop except at breakpoints or when finished
+        self._set_stopinfo(self.botframe, None, -1)
+
     def sigint_handler(self, signum, frame):
         """
         Handle a sigint signal. Break on the frame above this one.

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -314,7 +314,8 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
 
     # --- Methods overriden by us
     def set_continue(self):
-        """Stop only at breakpoints or when finished.
+        """
+        Stop only at breakpoints or when finished.
 
         Reimplemented to avoid stepping out of debugging if there are no
         breakpoints. We could add more later.


### PR DESCRIPTION
Calling `do_one_iteration` is not a good idea as it might process messages out of order.

Here, a new socket is created. It is a one way socket designed to skip the message queue, and runs in a thread. This means that:
 - Only messages that are explicitely sent to this socket are processed out of order, instead of all messages as it is the case now.
 - Any thread can make a blocking call to the frontend without needing to start an event loop.
 - We can set breakpoints while executing! 