### PR TITLE
PR: Prevent pdb syntax error from blocking the console

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -439,10 +439,10 @@ class SpyderPdb(pdb.Pdb, object):  # Inherits `object` to call super() in PY2
         """
         if line[:1] == '!':
             line = line[1:]
-        line = TransformerManager().transform_cell(line)
         locals = self.curframe_locals
         globals = self.curframe.f_globals
         try:
+            line = TransformerManager().transform_cell(line)
             try:
                 code = compile(line + '\n', '<stdin>', 'single')
             except SyntaxError:


### PR DESCRIPTION
While debugging, if the code raises a syntax error, the console becomes unusable:

```
if True:
    print(0)
 print(1)
```

This PR properly handles the exception

Fixes https://github.com/spyder-ide/spyder/issues/10588