### PR TITLE
PR: Correctly set namespace while debugging

### DIFF
--- a/spyder_kernels/customize/namespace_manager.py
+++ b/spyder_kernels/customize/namespace_manager.py
@@ -19,7 +19,7 @@ def _get_globals_locals():
         ns_locals = pdb.curframe_locals
         ns_globals = pdb.curframe.f_globals
     else:
-        ns_locals = {}
+        ns_locals = None
         ns_globals = get_ipython().user_ns
     return ns_globals, ns_locals
 
@@ -49,7 +49,7 @@ class NamespaceManager(object):
                  file_code=None):
         self.filename = filename
         self.ns_globals = namespace
-        self.ns_locals = {}
+        self.ns_locals = None
         self.current_namespace = current_namespace
         self._previous_filename = None
         self._previous_main = None
@@ -69,7 +69,7 @@ class NamespaceManager(object):
                 main_mod = ipython_shell.new_main_mod(
                     self.filename, '__main__')
                 self.ns_globals = main_mod.__dict__
-                self.ns_locals = {}
+                self.ns_locals = None
                 # Needed to allow pickle to reference main
                 if '__main__' in sys.modules:
                     self._previous_main = sys.modules['__main__']

--- a/spyder_kernels/customize/namespace_manager.py
+++ b/spyder_kernels/customize/namespace_manager.py
@@ -12,10 +12,22 @@ from IPython.core.getipython import get_ipython
 from spyder_kernels.py3compat import PY2
 
 
-def _get_globals():
-    """Return current namespace"""
-    ipython_shell = get_ipython()
-    return ipython_shell.user_ns
+def _get_globals_locals():
+    """Return current namespace."""
+    if get_ipython().kernel.is_debugging():
+        pdb = get_ipython().kernel._pdb_obj
+        ns_locals = pdb.curframe_locals
+        ns_globals = pdb.curframe.f_globals
+    else:
+        ns_locals = None
+        ns_globals = get_ipython().user_ns
+    return ns_globals, ns_locals
+
+
+def _set_globals_locals(ns_globals, ns_locals):
+    """Update current namespace."""
+    if not get_ipython().kernel.is_debugging():
+        get_ipython().user_ns.update(ns_globals)
 
 
 class NamespaceManager(object):
@@ -29,7 +41,7 @@ class NamespaceManager(object):
     def __init__(self, filename, namespace=None, current_namespace=False,
                  file_code=None):
         self.filename = filename
-        self.namespace = namespace
+        self.namespace = namespace, None
         self.current_namespace = current_namespace
         self._previous_filename = None
         self._previous_main = None
@@ -41,22 +53,22 @@ class NamespaceManager(object):
         Prepare the namespace.
         """
         # Save previous __file__
-        if self.namespace is None:
+        if self.namespace[0] is None:
             if self.current_namespace:
-                self.namespace = _get_globals()
+                self.namespace = _get_globals_locals()
             else:
                 ipython_shell = get_ipython()
                 main_mod = ipython_shell.new_main_mod(
                     self.filename, '__main__')
-                self.namespace = main_mod.__dict__
+                self.namespace = main_mod.__dict__, None
                 # Needed to allow pickle to reference main
                 if '__main__' in sys.modules:
                     self._previous_main = sys.modules['__main__']
                 sys.modules['__main__'] = main_mod
                 self._reset_main = True
-        if '__file__' in self.namespace:
-            self._previous_filename = self.namespace['__file__']
-        self.namespace['__file__'] = self.filename
+        if '__file__' in self.namespace[0]:
+            self._previous_filename = self.namespace[0]['__file__']
+        self.namespace[0]['__file__'] = self.filename
         if (self._file_code is not None
                 and not PY2
                 and isinstance(self._file_code, bytes)):
@@ -79,11 +91,11 @@ class NamespaceManager(object):
         Reset the namespace.
         """
         if not self.current_namespace:
-            get_ipython().user_ns.update(self.namespace)
+            _set_globals_locals(*self.namespace)
         if self._previous_filename:
-            self.namespace['__file__'] = self._previous_filename
-        elif '__file__' in self.namespace:
-            self.namespace.pop('__file__')
+            self.namespace[0]['__file__'] = self._previous_filename
+        elif '__file__' in self.namespace[0]:
+            self.namespace[0].pop('__file__')
         if self._previous_main:
             sys.modules['__main__'] = self._previous_main
         elif '__main__' in sys.modules and self._reset_main:

--- a/spyder_kernels/customize/namespace_manager.py
+++ b/spyder_kernels/customize/namespace_manager.py
@@ -19,15 +19,22 @@ def _get_globals_locals():
         ns_locals = pdb.curframe_locals
         ns_globals = pdb.curframe.f_globals
     else:
-        ns_locals = None
+        ns_locals = {}
         ns_globals = get_ipython().user_ns
     return ns_globals, ns_locals
 
 
 def _set_globals_locals(ns_globals, ns_locals):
     """Update current namespace."""
-    if not get_ipython().kernel.is_debugging():
+    if get_ipython().kernel.is_debugging():
+        pdb = get_ipython().kernel._pdb_obj
+        pdb.curframe.f_globals.update(ns_globals)
+        if ns_locals:
+            pdb.curframe_locals.update(ns_locals)
+    else:
         get_ipython().user_ns.update(ns_globals)
+        if ns_locals:
+            get_ipython().user_ns.update(ns_locals)
 
 
 class NamespaceManager(object):
@@ -41,7 +48,8 @@ class NamespaceManager(object):
     def __init__(self, filename, namespace=None, current_namespace=False,
                  file_code=None):
         self.filename = filename
-        self.namespace = namespace, None
+        self.ns_globals = namespace
+        self.ns_locals = {}
         self.current_namespace = current_namespace
         self._previous_filename = None
         self._previous_main = None
@@ -53,22 +61,23 @@ class NamespaceManager(object):
         Prepare the namespace.
         """
         # Save previous __file__
-        if self.namespace[0] is None:
+        if self.ns_globals is None:
             if self.current_namespace:
-                self.namespace = _get_globals_locals()
+                self.ns_globals, self.ns_locals = _get_globals_locals()
             else:
                 ipython_shell = get_ipython()
                 main_mod = ipython_shell.new_main_mod(
                     self.filename, '__main__')
-                self.namespace = main_mod.__dict__, None
+                self.ns_globals = main_mod.__dict__
+                self.ns_locals = {}
                 # Needed to allow pickle to reference main
                 if '__main__' in sys.modules:
                     self._previous_main = sys.modules['__main__']
                 sys.modules['__main__'] = main_mod
                 self._reset_main = True
-        if '__file__' in self.namespace[0]:
-            self._previous_filename = self.namespace[0]['__file__']
-        self.namespace[0]['__file__'] = self.filename
+        if '__file__' in self.ns_globals:
+            self._previous_filename = self.ns_globals['__file__']
+        self.ns_globals['__file__'] = self.filename
         if (self._file_code is not None
                 and not PY2
                 and isinstance(self._file_code, bytes)):
@@ -84,18 +93,18 @@ class NamespaceManager(object):
                 len(self._file_code), None,
                 [line + '\n' for line in self._file_code.splitlines()],
                 self.filename)
-        return self.namespace
+        return self.ns_globals, self.ns_locals
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """
         Reset the namespace.
         """
         if not self.current_namespace:
-            _set_globals_locals(*self.namespace)
+            _set_globals_locals(self.ns_globals, self.ns_locals)
         if self._previous_filename:
-            self.namespace[0]['__file__'] = self._previous_filename
-        elif '__file__' in self.namespace[0]:
-            self.namespace[0].pop('__file__')
+            self.ns_globals['__file__'] = self._previous_filename
+        elif '__file__' in self.ns_globals:
+            self.ns_globals.pop('__file__')
         if self._previous_main:
             sys.modules['__main__'] = self._previous_main
         elif '__main__' in sys.modules and self._reset_main:

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -996,7 +996,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         return
 
     with NamespaceManager(filename, namespace, current_namespace,
-                          file_code=file_code) as namespace:
+                          file_code=file_code) as (ns_globals, ns_locals):
         sys.argv = [filename]
         if args is not None:
             for arg in shlex.split(args):
@@ -1020,7 +1020,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
             with io.open(filename, encoding='utf-8') as f:
                 ipython_shell.run_cell_magic('cython', '', f.read())
         else:
-            exec_code(file_code, filename, *namespace)
+            exec_code(file_code, filename, ns_globals, ns_locals)
 
         clear_post_mortem()
         sys.argv = ['']
@@ -1103,8 +1103,8 @@ def runcell(cellname, filename=None):
     except Exception:
         file_code = None
     with NamespaceManager(filename, current_namespace=True,
-                          file_code=file_code) as namespace:
-        exec_code(cell_code, filename, *namespace)
+                          file_code=file_code) as (ns_globals, ns_locals):
+        exec_code(cell_code, filename, ns_globals, ns_locals)
 
 
 builtins.runcell = runcell

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -868,7 +868,7 @@ def get_debugger(filename):
     return debugger, filename
 
 
-def exec_code(code, filename, namespace):
+def exec_code(code, filename, ns_globals, ns_locals=None):
     """Execute code and display any exception."""
     if PY2 and isinstance(filename, unicode):
         filename = encode(filename)
@@ -886,7 +886,7 @@ def exec_code(code, filename, namespace):
                 # Avoid removing lines
                 tm.cleanup_transforms = []
             code = tm.transform_cell(code)
-        exec(compile(code, filename, 'exec'), namespace)
+        exec(compile(code, filename, 'exec'), ns_globals, ns_locals)
     except SystemExit as status:
         # ignore exit(0)
         if status.code:
@@ -985,7 +985,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
             with io.open(filename, encoding='utf-8') as f:
                 ipython_shell.run_cell_magic('cython', '', f.read())
         else:
-            exec_code(file_code, filename, namespace)
+            exec_code(file_code, filename, *namespace)
 
         clear_post_mortem()
         sys.argv = ['']
@@ -1069,7 +1069,7 @@ def runcell(cellname, filename=None):
         file_code = None
     with NamespaceManager(filename, current_namespace=True,
                           file_code=file_code) as namespace:
-        exec_code(cell_code, filename, namespace)
+        exec_code(cell_code, filename, *namespace)
 
 
 builtins.runcell = runcell


### PR DESCRIPTION
`runfile` and `runcell` can be used while debugging to run code. However, the namespace is not properly set. This PR solves this problem.