### PR TITLE
PR: Use a timeout in CommBase if a call passes one different from None

### DIFF
--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -404,7 +404,7 @@ class CommBase(object):
         call_name = call_dict['call_name']
 
         # Wait for the blocking call
-        if 'timeout' in settings:
+        if 'timeout' in settings and settings['timeout'] is not None:
             timeout = settings['timeout']
         else:
             timeout = 3  # Seconds

--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -67,6 +67,9 @@ logger = logging.getLogger(__name__)
 # To be able to get and set variables between Python 2 and 3
 DEFAULT_PICKLE_PROTOCOL = 2
 
+# Max timeout (in secs) for blocking calls
+TIMEOUT = 3
+
 
 class CommError(RuntimeError):
     pass
@@ -407,7 +410,7 @@ class CommBase(object):
         if 'timeout' in settings and settings['timeout'] is not None:
             timeout = settings['timeout']
         else:
-            timeout = 3  # Seconds
+            timeout = TIMEOUT
 
         self._wait_reply(call_id, call_name, timeout)
 

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -122,10 +122,14 @@ class FrontendComm(CommBase):
         if out_stream:
             out_stream.flush(zmq.POLLOUT)
 
-    def remote_call(self, comm_id=None, blocking=False, callback=None):
+    def remote_call(self, comm_id=None, blocking=False, callback=None,
+                    timeout=None):
         """Get a handler for remote calls."""
         return super(FrontendComm, self).remote_call(
-                blocking=blocking, comm_id=comm_id, callback=callback)
+            blocking=blocking,
+            comm_id=comm_id,
+            callback=callback,
+            timeout=timeout)
 
     # --- Private --------
     def _wait_reply(self, call_id, call_name, timeout):

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -72,7 +72,7 @@ class SpyderKernel(IPythonKernel):
         self._do_publish_pdb_state = True
         self._mpl_backend_error = None
 
-    def frontend_call(self, blocking=False, broadcast=True):
+    def frontend_call(self, blocking=False, broadcast=True, timeout=None):
         """Call the frontend."""
         # If not broadcast, send only to the calling comm
         if broadcast:
@@ -81,7 +81,9 @@ class SpyderKernel(IPythonKernel):
             comm_id = self.frontend_comm.calling_comm_id
 
         return self.frontend_comm.remote_call(
-            blocking=blocking, comm_id=comm_id)
+            blocking=blocking,
+            comm_id=comm_id,
+            timeout=timeout)
 
     @property
     def _pdb_frame(self):


### PR DESCRIPTION
* This is to account for some calls that can pass a timeout (e.g. a get_value call from the frontend) and others that don't (which will pass by default a timeout of None).
* This also adds a timeout kwarg to `frontend_call` to have variable timeout calls from the frontend to the kernel.