### PR TITLE
PR: Add an option to namespace view settings to exclude callables and modules

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -650,7 +650,7 @@ def test_callables_and_modules(kernel, exclude_callables_and_modules,
                                exclude_unsupported):
     """
     Tests that callables and modules are in the namespace view only
-    when the right options is passed to the kernel.
+    when the right options are passed to the kernel.
     """
     kernel.do_execute('import numpy', True)
     kernel.do_execute('a = 10', True)

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -104,29 +104,38 @@ def kernel(request):
     """Console kernel fixture"""
     # Get kernel instance
     kernel = get_kernel()
-    kernel.namespace_view_settings = {'check_all': False,
-                                      'exclude_private': True,
-                                      'exclude_uppercase': True,
-                                      'exclude_capitalized': False,
-                                      'exclude_unsupported': True,
-                                      'excluded_names': ['nan', 'inf',
-                                                         'infty',
-                                                         'little_endian',
-                                                         'colorbar_doc',
-                                                         'typecodes',
-                                                         '__builtins__',
-                                                         '__main__',
-                                                         '__doc__',
-                                                         'NaN', 'Inf',
-                                                         'Infinity',
-                                                         'sctypes',
-                                                         'rcParams',
-                                                         'rcParamsDefault',
-                                                         'sctypeNA', 'typeNA',
-                                                         'False_', 'True_'],
-                                      'minmax': False}
-    # Teardown
+    kernel.namespace_view_settings = {
+        'check_all': False,
+        'exclude_private': True,
+        'exclude_uppercase': True,
+        'exclude_capitalized': False,
+        'exclude_unsupported': True,
+        'exclude_callables_or_modules': True,
+        'excluded_names': [
+            'nan',
+            'inf',
+            'infty',
+            'little_endian',
+            'colorbar_doc',
+            'typecodes',
+            '__builtins__',
+            '__main__',
+            '__doc__',
+            'NaN',
+            'Inf',
+            'Infinity',
+            'sctypes',
+            'rcParams',
+            'rcParamsDefault',
+            'sctypeNA',
+            'typeNA',
+            'False_',
+            'True_'
+        ],
+        'minmax': False
+    }
 
+    # Teardown
     def reset_kernel():
         kernel.do_execute('reset -f', True)
     request.addfinalizer(reset_kernel)

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -110,7 +110,7 @@ def kernel(request):
         'exclude_uppercase': True,
         'exclude_capitalized': False,
         'exclude_unsupported': True,
-        'exclude_callables_or_modules': True,
+        'exclude_callables_and_modules': True,
         'excluded_names': [
             'nan',
             'inf',
@@ -644,9 +644,9 @@ def test_do_complete(kernel):
     assert 'baba' in match['matches']
 
 
-@pytest.mark.parametrize("exclude_callables_or_modules", [True, False])
+@pytest.mark.parametrize("exclude_callables_and_modules", [True, False])
 @pytest.mark.parametrize("exclude_unsupported", [True, False])
-def test_callables_and_modules(kernel, exclude_callables_or_modules,
+def test_callables_and_modules(kernel, exclude_callables_and_modules,
                                exclude_unsupported):
     """
     Tests that callables and modules are in the namespace view only
@@ -657,13 +657,13 @@ def test_callables_and_modules(kernel, exclude_callables_or_modules,
     kernel.do_execute('def f(x): return x', True)
     settings = kernel.namespace_view_settings
 
-    settings['exclude_callables_or_modules'] = exclude_callables_or_modules
+    settings['exclude_callables_and_modules'] = exclude_callables_and_modules
     settings['exclude_unsupported'] = exclude_unsupported
     nsview = kernel.get_namespace_view()
 
     # Callables and modules should always be in nsview when the option
     # is active.
-    if not exclude_callables_or_modules:
+    if not exclude_callables_and_modules:
         assert 'numpy' in nsview.keys()
         assert 'f' in nsview.keys()
     else:
@@ -674,7 +674,7 @@ def test_callables_and_modules(kernel, exclude_callables_or_modules,
     assert 'a' in nsview.keys()
 
     # Restore settings for other tests
-    settings['exclude_callables_or_modules'] = True
+    settings['exclude_callables_and_modules'] = True
     settings['exclude_unsupported'] = True
 
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -109,7 +109,7 @@ def kernel(request):
         'exclude_private': True,
         'exclude_uppercase': True,
         'exclude_capitalized': False,
-        'exclude_unsupported': True,
+        'exclude_unsupported': False,
         'exclude_callables_and_modules': True,
         'excluded_names': [
             'nan',
@@ -675,7 +675,7 @@ def test_callables_and_modules(kernel, exclude_callables_and_modules,
 
     # Restore settings for other tests
     settings['exclude_callables_and_modules'] = True
-    settings['exclude_unsupported'] = True
+    settings['exclude_unsupported'] = False
 
 
 if __name__ == "__main__":

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -567,7 +567,9 @@ def is_supported(value, check_all=False, filters=None, iterate=False):
     assert filters is not None
     if value is None:
         return True
-    if not is_editable_type(value):
+    if is_callable_or_module(value):
+        return True
+    elif not is_editable_type(value):
         return False
     elif not isinstance(value, filters):
         return False

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -605,7 +605,7 @@ def is_callable_or_module(value):
 def globalsfilter(input_dict, check_all=False, filters=None,
                   exclude_private=None, exclude_capitalized=None,
                   exclude_uppercase=None, exclude_unsupported=None,
-                  excluded_names=None, exclude_callables_or_modules=None):
+                  excluded_names=None, exclude_callables_and_modules=None):
     """Keep objects in namespace view according to different criteria."""
     output_dict = {}
     for key, value in list(input_dict.items()):
@@ -615,7 +615,7 @@ def globalsfilter(input_dict, check_all=False, filters=None,
             (exclude_uppercase and key.isupper() and
              len(key) > 1 and not key[1:].isdigit()) or
             (key in excluded_names) or
-            (exclude_callables_or_modules and is_callable_or_module(value)) or
+            (exclude_callables_and_modules and is_callable_or_module(value)) or
             (exclude_unsupported and
              not is_supported(value, check_all=check_all, filters=filters))
         )
@@ -630,7 +630,7 @@ def globalsfilter(input_dict, check_all=False, filters=None,
 REMOTE_SETTINGS = ('check_all', 'exclude_private', 'exclude_uppercase',
                    'exclude_capitalized', 'exclude_unsupported',
                    'excluded_names', 'minmax', 'show_callable_attributes',
-                   'show_special_attributes', 'exclude_callables_or_modules')
+                   'show_special_attributes', 'exclude_callables_and_modules')
 
 
 def get_supported_types():
@@ -685,7 +685,7 @@ def get_remote_data(data, settings, mode, more_excluded_names=None):
         exclude_uppercase=settings['exclude_uppercase'],
         exclude_capitalized=settings['exclude_capitalized'],
         exclude_unsupported=settings['exclude_unsupported'],
-        exclude_callables_or_modules=settings['exclude_callables_or_modules'],
+        exclude_callables_and_modules=settings['exclude_callables_and_modules'],
         excluded_names=excluded_names)
 
 

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -13,6 +13,7 @@ Utilities
 from __future__ import print_function
 
 from itertools import islice
+import inspect
 import re
 
 # Local imports
@@ -562,7 +563,7 @@ def get_human_readable_type(item):
 # CollectionsEditor)
 #==============================================================================
 def is_supported(value, check_all=False, filters=None, iterate=False):
-    """Return True if the value is supported, False otherwise"""
+    """Return True if value is supported, False otherwise."""
     assert filters is not None
     if value is None:
         return True
@@ -590,21 +591,32 @@ def is_supported(value, check_all=False, filters=None, iterate=False):
     return True
 
 
+def is_callable_or_module(value):
+    """Return True if value is a callable or module, False otherwise."""
+    try:
+        callable_or_module = callable(value) or inspect.ismodule(value)
+    except Exception:
+        callable_or_module = False
+    return callable_or_module
+
+
 def globalsfilter(input_dict, check_all=False, filters=None,
                   exclude_private=None, exclude_capitalized=None,
                   exclude_uppercase=None, exclude_unsupported=None,
-                  excluded_names=None):
-    """Keep only objects that can be pickled"""
+                  excluded_names=None, exclude_callables_or_modules=None):
+    """Keep objects in namespace view according to different criteria."""
     output_dict = {}
     for key, value in list(input_dict.items()):
-        excluded = (exclude_private and key.startswith('_')) or \
-                   (exclude_capitalized and key[0].isupper()) or \
-                   (exclude_uppercase and key.isupper()
-                    and len(key) > 1 and not key[1:].isdigit()) or \
-                   (key in excluded_names) or \
-                   (exclude_unsupported and \
-                    not is_supported(value, check_all=check_all,
-                                     filters=filters))
+        excluded = (
+            (exclude_private and key.startswith('_')) or
+            (exclude_capitalized and key[0].isupper()) or
+            (exclude_uppercase and key.isupper() and
+             len(key) > 1 and not key[1:].isdigit()) or
+            (key in excluded_names) or
+            (exclude_callables_or_modules and is_callable_or_module(value)) or
+            (exclude_unsupported and
+             not is_supported(value, check_all=check_all, filters=filters))
+        )
         if not excluded:
             output_dict[key] = value
     return output_dict
@@ -616,7 +628,7 @@ def globalsfilter(input_dict, check_all=False, filters=None,
 REMOTE_SETTINGS = ('check_all', 'exclude_private', 'exclude_uppercase',
                    'exclude_capitalized', 'exclude_unsupported',
                    'excluded_names', 'minmax', 'show_callable_attributes',
-                   'show_special_attributes')
+                   'show_special_attributes', 'exclude_callables_or_modules')
 
 
 def get_supported_types():
@@ -663,13 +675,16 @@ def get_remote_data(data, settings, mode, more_excluded_names=None):
     excluded_names = settings['excluded_names']
     if more_excluded_names is not None:
         excluded_names += more_excluded_names
-    return globalsfilter(data, check_all=settings['check_all'],
-                         filters=tuple(supported_types[mode]),
-                         exclude_private=settings['exclude_private'],
-                         exclude_uppercase=settings['exclude_uppercase'],
-                         exclude_capitalized=settings['exclude_capitalized'],
-                         exclude_unsupported=settings['exclude_unsupported'],
-                         excluded_names=excluded_names)
+    return globalsfilter(
+        data,
+        check_all=settings['check_all'],
+        filters=tuple(supported_types[mode]),
+        exclude_private=settings['exclude_private'],
+        exclude_uppercase=settings['exclude_uppercase'],
+        exclude_capitalized=settings['exclude_capitalized'],
+        exclude_unsupported=settings['exclude_unsupported'],
+        exclude_callables_or_modules=settings['exclude_callables_or_modules'],
+        excluded_names=excluded_names)
 
 
 def make_remote_view(data, settings, more_excluded_names=None):


### PR DESCRIPTION
This will allow us to only exclude these kind of objects by default in Spyder 4, so users can have access to the Object Explorer integrated by @dalthviz.

A PR is still missing in the Spyder side, which I'll open shortly.