### PR TITLE
PR: Process first frame in Pdb

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -395,9 +395,12 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                     logger.debug(
                         "Could not send a Pdb continue call to the frontend.")
 
-    def notify_spyder(self, frame):
+    def notify_spyder(self, frame=None):
         """Send kernel state to the frontend."""
-        if not frame:
+        if frame is None:
+            frame = self.curframe
+
+        if frame is None:
             return
 
         kernel = get_ipython().kernel


### PR DESCRIPTION
Fix an issue where spyder is not notified on the first frame because it is None