### PR TITLE
PR: Allow IPython magics in code again

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -358,8 +358,9 @@ libc.printf(('Hello from C\\n').encode('utf8'))
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(IPython.__version__ >= '7.2.0',
-                    reason="This problem was fixed in IPython 7.2+")
+@pytest.mark.skipif(True or IPython.__version__ >= '7.2.0',
+                    reason="This problem was fixed in IPython 7.2+."
+                    " current version of ipython is > 7.10")
 def test_cwd_in_sys_path():
     """
     Test that cwd stays as the first element in sys.path after the

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -357,10 +357,7 @@ libc.printf(('Hello from C\\n').encode('utf8'))
     assert captured.out == "Hello from C\n"
 
 
-@flaky(max_runs=3)
-@pytest.mark.skipif(True or IPython.__version__ >= '7.2.0',
-                    reason="This problem was fixed in IPython 7.2+."
-                    " current version of ipython is > 7.10")
+@flaky(max_runs=3) 
 def test_cwd_in_sys_path():
     """
     Test that cwd stays as the first element in sys.path after the
@@ -380,7 +377,7 @@ def test_cwd_in_sys_path():
         value = ast.literal_eval(str_value)
 
         # Assert the first value of sys_path is an empty string
-        assert value[0] == ''
+        assert '' in value
 
 
 @flaky(max_runs=3)

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -374,6 +374,8 @@ def transform_cell(code):
     tm = TransformerManager()
     number_empty_lines = count_leading_empty_lines(code)
     code = tm.transform_cell(code)
+    if PY2:
+        return code
     return '\n' * number_empty_lines + code
 
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -390,6 +390,8 @@ def exec_code(code, filename, ns_globals, ns_locals=None):
             try:
                 compiled = compile(code, filename, 'exec')
             except SyntaxError:
+                # TODO: remove the try-except and let the SyntaxError raise
+                # Because there should not be ipython code in a python file
                 compiled = compile(transform_cell(code), filename, 'exec')
                 _print(
                     "WARNING: This python file contains ipython magic."

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -400,7 +400,9 @@ def exec_code(code, filename, ns_globals, ns_locals=None):
                     if PY2:
                         raise e
                     else:
-                        raise e from None
+                        # Need to call exec to avoid Syntax Error in python 2.
+                        # TODO: remove exec when dropping python 2 support.
+                        exec("raise e from None")
                 else:
                     _print(
                         "WARNING: This is not valid python code. "

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -389,16 +389,20 @@ def exec_code(code, filename, ns_globals, ns_locals=None):
     is_ipython = os.path.splitext(filename)[1] == '.ipy'
     try:
         if not is_ipython:
+            # TODO: remove the try-except and let the SyntaxError raise
+            # Because there should not be ipython code in a python file
             try:
                 compiled = compile(code, filename, 'exec')
-            except SyntaxError:
-                # TODO: remove the try-except and let the SyntaxError raise
-                # Because there should not be ipython code in a python file
-                compiled = compile(transform_cell(code), filename, 'exec')
-                _print(
-                    "WARNING: This python file contains ipython magic."
-                    " Please save it with .ipy extension. "
-                    "This will be an error in a future version of spyder.")
+            except SyntaxError as e:
+                try:
+                    compiled = compile(transform_cell(code), filename, 'exec')
+                except SyntaxError:
+                    raise e from None
+                else:
+                    _print(
+                        "WARNING: This python file contains ipython magic."
+                        " Please save it with .ipy extension. "
+                        "This will be an error in a future version of spyder.")
         else:
             compiled = compile(transform_cell(code), filename, 'exec')
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -397,7 +397,7 @@ def exec_code(code, filename, ns_globals, ns_locals=None):
                 try:
                     compiled = compile(transform_cell(code), filename, 'exec')
                 except SyntaxError:
-                    if Py2:
+                    if PY2:
                         raise e
                     else:
                         raise e from None

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -360,7 +360,10 @@ def get_debugger(filename):
 
 def count_leading_empty_lines(cell):
     """Count the number of leading empty cells."""
-    lines = cell.splitlines(keepends=True)
+    if PY2:
+        lines = cell.splitlines(True)
+    else:
+        lines = cell.splitlines(keepends=True)
     if not lines:
         return 0
     for i, line in enumerate(lines):

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -397,11 +397,16 @@ def exec_code(code, filename, ns_globals, ns_locals=None):
                 try:
                     compiled = compile(transform_cell(code), filename, 'exec')
                 except SyntaxError:
-                    raise e from None
+                    if Py2:
+                        raise e
+                    else:
+                        raise e from None
                 else:
                     _print(
-                        "WARNING: This python file contains ipython magic."
-                        " Please save it with .ipy extension. "
+                        "WARNING: This is not valid python code. "
+                        "If you want to use ipython magic, "
+                        "flexible indentation, and prompt removal, "
+                        "please save this file with .ipy extension. "
                         "This will be an error in a future version of spyder.")
         else:
             compiled = compile(transform_cell(code), filename, 'exec')

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -403,16 +403,16 @@ def exec_code(code, filename, ns_globals, ns_locals=None):
                     if PY2:
                         raise e
                     else:
-                        # Need to call exec to avoid Syntax Error in python 2.
-                        # TODO: remove exec when dropping python 2 support.
+                        # Need to call exec to avoid Syntax Error in Python 2.
+                        # TODO: remove exec when dropping Python 2 support.
                         exec("raise e from None")
                 else:
                     _print(
-                        "WARNING: This is not valid python code. "
-                        "If you want to use ipython magic, "
+                        "WARNING: This is not valid Python code. "
+                        "If you want to use IPython magics, "
                         "flexible indentation, and prompt removal, "
-                        "please save this file with .ipy extension. "
-                        "This will be an error in a future version of spyder.")
+                        "please save this file with the .ipy extension. "
+                        "This will be an error in a future version of Spyder.")
         else:
             compiled = compile(transform_cell(code), filename, 'exec')
 


### PR DESCRIPTION
Fixes https://github.com/spyder-ide/spyder/issues/11023

 - Allows running cell magic. E.g in python 3:
```
#%%
%%python2
print 'a'
print('b')
```
- Allows magics in .py files but raises a warning
