### PR TITLE
PR: Prevent completion from changing local objects while debugging

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -47,6 +47,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
     def __init__(self, completekey='tab', stdin=None, stdout=None,
                  skip=None, nosigint=False):
         """Init Pdb."""
+        self.curframe_locals = None
         # Only set to true when calling debugfile
         self.continue_if_has_breakpoints = False
         self.pdb_ignore_lib = False
@@ -214,8 +215,12 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
             kernel = get_ipython().kernel
             # Make complete call with current frame
             if self.curframe:
-                Frame = namedtuple("Frame", ["f_locals", "f_globals"])
-                frame = Frame(self.curframe_locals, self.curframe.f_globals)
+                if self.curframe_locals:
+                    Frame = namedtuple("Frame", ["f_locals", "f_globals"])
+                    frame = Frame(self.curframe_locals,
+                                  self.curframe.f_globals)
+                else:
+                    frame = self.curframe
                 kernel.shell.set_completer_frame(frame)
             result = kernel._do_complete(code, cursor_pos)
             # Reset frame

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -11,6 +11,7 @@ import pdb
 import sys
 import logging
 import traceback
+from collections import namedtuple
 
 from IPython.core.getipython import get_ipython
 from IPython.core.debugger import Pdb as ipyPdb
@@ -213,10 +214,9 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
             kernel = get_ipython().kernel
             # Make complete call with current frame
             if self.curframe:
-                # Set locals correctly
-                completer = kernel.shell.Completer
-                completer.namespace = self.curframe_locals
-                completer.global_namespace = self.curframe.f_globals
+                Frame = namedtuple("Frame", ["f_locals", "f_globals"])
+                frame = Frame(self.curframe_locals, self.curframe.f_globals)
+                kernel.shell.set_completer_frame(frame)
             result = kernel._do_complete(code, cursor_pos)
             # Reset frame
             kernel.shell.set_completer_frame()

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -213,7 +213,10 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
             kernel = get_ipython().kernel
             # Make complete call with current frame
             if self.curframe:
-                kernel.shell.set_completer_frame(self.curframe)
+                # Set locals correctly
+                completer = kernel.shell.Completer
+                completer.namespace = self.curframe_locals
+                completer.global_namespace = self.curframe.f_globals
             result = kernel._do_complete(code, cursor_pos)
             # Reset frame
             kernel.shell.set_completer_frame()


### PR DESCRIPTION
calling `self.curframe.f_locals` resets locals in pdb. This PR avoid that by using `self.curframe_locals` instead. (Which exists for precisely this reason)