### PR TITLE
PR: Remove the current working directory from sys.path for Python 3.7+

### DIFF
--- a/spyder_kernels/console/__main__.py
+++ b/spyder_kernels/console/__main__.py
@@ -6,6 +6,17 @@
 # (see spyder_kernels/__init__.py for details)
 # -----------------------------------------------------------------------------
 
+import sys
+import os
+
+
 if __name__ == '__main__':
+    # Remove the current working directory from sys.path for Python 3.7+
+    # because since that version it's added by default to sys.path when
+    # using 'python -m'.
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
+        if os.getcwd() in sys.path:
+            sys.path.remove(os.getcwd())
+
     from spyder_kernels.console import start
     start.main()

--- a/spyder_kernels/console/__main__.py
+++ b/spyder_kernels/console/__main__.py
@@ -15,8 +15,9 @@ if __name__ == '__main__':
     # because since that version it's added by default to sys.path when
     # using 'python -m'.
     if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
-        if os.getcwd() in sys.path:
-            sys.path.remove(os.getcwd())
+        cwd = os.getcwd()
+        if cwd in sys.path:
+            sys.path.remove(cwd)
 
     from spyder_kernels.console import start
     start.main()


### PR DESCRIPTION
Since that version `os.getcwd` is added by default to sys.path when using `python -m` to run a module, which is precisely what we do to start kernels in Spyder. [Here](https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior) is the entry about that change in the Python 3.7 release notes (it took me a couple of hours to find it).

Pinging @jitseniesen about this because (I think) we also use `python -m` in `spyder-notebook`.

TODO:

- [x] I'm going to create a PR with a test for this in Spyder so we can be absolutely sure this problem doesn't resurface again later.