### PR TITLE
PR: Add warning on console if file is not saved

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -287,13 +287,22 @@ if not PY2:
             removed before execution.
             """
             try:
-                return _old_preparation_data(name)
+                d = _old_preparation_data(name)
             except AttributeError:
                 main_module = sys.modules['__main__']
                 # Any string for __spec__ does the job
                 main_module.__spec__ = ''
-                return _old_preparation_data(name)
-
+                d = _old_preparation_data(name)
+            # On windows, there is no fork, so we need to save the main file
+            # and import it
+            if (os.name == 'nt' and 'init_main_from_path' in d
+                    and not os.path.exists(d['init_main_from_path'])):
+                _print(
+                    "Warning: multiprocessing may need main file to exist. "
+                    "Please save {}".format(d['init_main_from_path']))
+                # Remove path as the subprocess can't do anything with it
+                del d['init_main_from_path']
+            return d
         multiprocessing.spawn.get_preparation_data = _patched_preparation_data
     except Exception:
         pass

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -298,7 +298,7 @@ if not PY2:
             if (os.name == 'nt' and 'init_main_from_path' in d
                     and not os.path.exists(d['init_main_from_path'])):
                 _print(
-                    "Warning: multiprocessing may need main file to exist. "
+                    "Warning: multiprocessing may need the main file to exist. "
                     "Please save {}".format(d['init_main_from_path']))
                 # Remove path as the subprocess can't do anything with it
                 del d['init_main_from_path']


### PR DESCRIPTION
Add warning to avoid problems I had with https://github.com/micro-manager/pycro-manager/issues/42

Basically, if you run a script that was not saved, spyder fakes a file. As there is no `fork()` on window, `multiprocessing` can't just copy the content of the memory and has to restore the state somehow. Part of doing it is to import the main file. But if the main file doesn't exist, then that will fail.