### PR TITLE
PR: Fix a problem caused by ipykernel 5.3.1

### DIFF
--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -295,11 +295,23 @@ def main():
     while '' in sys.path:
         sys.path.remove('')
 
-    # Fire up the kernel instance.
+    # Main imports
     from ipykernel.kernelapp import IPKernelApp
     from spyder_kernels.console.kernel import SpyderKernel
 
-    kernel = IPKernelApp.instance()
+    class SpyderKernelApp(IPKernelApp):
+
+        def init_pdb(self):
+            """
+            This method was added in IPykernel 5.3.1 and it replaces
+            the debugger used by the kernel with a new class
+            introduced in IPython 7.15 during kernel's initialization.
+            Therefore, it doesn't allow us to use our debugger.
+            """
+            pass
+
+    # Fire up the kernel instance.
+    kernel = SpyderKernelApp.instance()
     kernel.kernel_class = SpyderKernel
     try:
         kernel.config = kernel_config()


### PR DESCRIPTION
A new method introduced in `ipykernel` **5.3.1**, added to `IPKernelApp` and called during kernel initialization prevented us to use our own debugger. Overriding it and making it pass fixed the issue. You can see PR ipython/ipykernel#490 for the details.

This PR also takes the opportunity to move several methods of `SpyderKernel` in more suitable places.