### PR TITLE
PR: Hide runcell and runfile frames using a new IPython feature

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -400,6 +400,8 @@ def transform_cell(code):
 
 def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False):
     """Execute code and display any exception."""
+    # Tell IPython to hide this frame
+    __tracebackhide__ = True
     global SHOW_INVALID_SYNTAX_MSG
 
     if PY2:
@@ -436,7 +438,6 @@ def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False):
                         SHOW_INVALID_SYNTAX_MSG = False
         else:
             compiled = compile(transform_cell(code), filename, 'exec')
-
         exec(compiled, ns_globals, ns_locals)
     except SystemExit as status:
         # ignore exit(0)
@@ -478,6 +479,8 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
     post_mortem: boolean, whether to enter post-mortem mode on error
     current_namespace: if true, run the file in the current namespace
     """
+    # Tell IPython to hide this frame
+    __tracebackhide__ = True
     ipython_shell = get_ipython()
     if filename is None:
         filename = get_current_file_name()
@@ -554,6 +557,8 @@ def debugfile(filename=None, args=None, wdir=None, post_mortem=False,
     wdir: working directory
     post_mortem: boolean, included for compatiblity with runfile
     """
+    # Tell IPython to hide this frame
+    __tracebackhide__ = True
     if filename is None:
         filename = get_current_file_name()
         if filename is None:
@@ -582,6 +587,8 @@ def runcell(cellname, filename=None, post_mortem=False):
     filename : str
         Needed to allow for proper traceback links.
     """
+    # Tell IPython to hide this frame
+    __tracebackhide__ = True
     if filename is None:
         filename = get_current_file_name()
         if filename is None:
@@ -630,6 +637,8 @@ builtins.runcell = runcell
 
 def debugcell(cellname, filename=None, post_mortem=False):
     """Debug a cell."""
+    # Tell IPython to hide this frame
+    __tracebackhide__ = True
     if filename is None:
         filename = get_current_file_name()
         if filename is None:

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -400,7 +400,7 @@ def transform_cell(code):
 
 def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False):
     """Execute code and display any exception."""
-    # Tell IPython to hide this frame
+    # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
     global SHOW_INVALID_SYNTAX_MSG
 
@@ -479,7 +479,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
     post_mortem: boolean, whether to enter post-mortem mode on error
     current_namespace: if true, run the file in the current namespace
     """
-    # Tell IPython to hide this frame
+    # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
     ipython_shell = get_ipython()
     if filename is None:
@@ -557,7 +557,7 @@ def debugfile(filename=None, args=None, wdir=None, post_mortem=False,
     wdir: working directory
     post_mortem: boolean, included for compatiblity with runfile
     """
-    # Tell IPython to hide this frame
+    # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
     if filename is None:
         filename = get_current_file_name()
@@ -587,7 +587,7 @@ def runcell(cellname, filename=None, post_mortem=False):
     filename : str
         Needed to allow for proper traceback links.
     """
-    # Tell IPython to hide this frame
+    # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
     if filename is None:
         filename = get_current_file_name()
@@ -637,7 +637,7 @@ builtins.runcell = runcell
 
 def debugcell(cellname, filename=None, post_mortem=False):
     """Debug a cell."""
-    # Tell IPython to hide this frame
+    # Tell IPython to hide this frame (>7.16)
     __tracebackhide__ = True
     if filename is None:
         filename = get_current_file_name()


### PR DESCRIPTION
Use the new feature introduced in https://github.com/ipython/ipython/pull/12359 to hide spyder internals