### PR TITLE
PR: Set multiprocessing ORIGINAL_DIR at startup

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -522,14 +522,20 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
             for arg in shlex.split(args):
                 sys.argv.append(arg)
         if wdir is not None:
-            try:
-                wdir = wdir.decode('utf-8')
-            except (UnicodeError, TypeError, AttributeError):
-                # UnicodeError, TypeError --> eventually raised in Python 2
-                # AttributeError --> systematically raised in Python 3
-                pass
+            if PY2:
+                try:
+                    wdir = wdir.decode('utf-8')
+                except (UnicodeError, TypeError, AttributeError):
+                    # UnicodeError, TypeError --> eventually raised in Python 2
+                    pass
             if os.path.isdir(wdir):
                 os.chdir(wdir)
+                # See https://github.com/spyder-ide/spyder/issues/13632
+                if "multiprocessing.process" in sys.modules:
+                    import multiprocessing.process
+                    multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
+                        wdir)
+
             else:
                 _print("Working directory {} doesn't exist.\n".format(wdir))
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -532,10 +532,12 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
                 os.chdir(wdir)
                 # See https://github.com/spyder-ide/spyder/issues/13632
                 if "multiprocessing.process" in sys.modules:
-                    import multiprocessing.process
-                    multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
-                        wdir)
-
+                    try:
+                        import multiprocessing.process
+                        multiprocessing.process.ORIGINAL_DIR = os.path.abspath(
+                            wdir)
+                    except Exception:
+                        pass
             else:
                 _print("Working directory {} doesn't exist.\n".format(wdir))
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -525,7 +525,7 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
             if PY2:
                 try:
                     wdir = wdir.decode('utf-8')
-                except (UnicodeError, TypeError, AttributeError):
+                except (UnicodeError, TypeError):
                     # UnicodeError, TypeError --> eventually raised in Python 2
                     pass
             if os.path.isdir(wdir):


### PR DESCRIPTION
sets "Original wdir" before running a file

Fixes spyder-ide/spyder#13632