### PR TITLE
PR: Catch errors when trying to get the len of an object

### DIFF
--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -118,28 +118,33 @@ def try_to_eval(value):
     except (NameError, SyntaxError, ImportError):
         return value
 
-    
+
 def get_size(item):
     """Return shape/size/len of an item of arbitrary type"""
-    if hasattr(item, 'shape') and isinstance(item.shape, (tuple, integer)):
-        try:
-            return item.shape
-        except RecursionError:
-            # This is necessary to avoid an error when trying to
-            # get the shape of these objects.
-            # Fixes spyder-ide/spyder-kernels#217
-            return (-1, -1)
-    elif hasattr(item, 'size') and isinstance(item.size, (tuple, integer)):
-        try:
-            return item.size
-        except RecursionError:
-            return (-1, -1)
-    elif hasattr(item, '__len__'):
-        try:
+    try:
+        if hasattr(item, 'shape') and isinstance(item.shape, (tuple, integer)):
+            try:
+                if item.shape:
+                    return item.shape
+                else:
+                    # Scalar value
+                    return 1
+            except RecursionError:
+                # This is necessary to avoid an error when trying to
+                # get the shape of these objects.
+                # Fixes spyder-ide/spyder-kernels#217
+                return (-1, -1)
+        elif hasattr(item, 'size') and isinstance(item.size, (tuple, integer)):
+            try:
+                return item.size
+            except RecursionError:
+                return (-1, -1)
+        elif hasattr(item, '__len__'):
             return len(item)
-        except Exception:
+        else:
             return 1
-    else:
+    except Exception:
+        # There is one item
         return 1
 
 

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -135,7 +135,10 @@ def get_size(item):
         except RecursionError:
             return (-1, -1)
     elif hasattr(item, '__len__'):
-        return len(item)
+        try:
+            return len(item)
+        except Exception:
+            return 1
     else:
         return 1
 


### PR DESCRIPTION
This address https://github.com/spyder-ide/spyder/issues/13891 and spyder-ide/spyder#13892

having __len__ doesn't mean len will return without errors