### PR TITLE
PR: Add extra validation to is_module_installed

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -16,7 +16,6 @@ jobs:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'ubuntu'
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       fail-fast: false 
       matrix:

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -16,7 +16,6 @@ jobs:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'macos'
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       fail-fast: false 
       matrix:

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -16,7 +16,6 @@ jobs:
       CI: True
       PYTHON_VERSION: ${{ matrix.PYTHON_VERSION }}
       RUNNER_OS: 'windows'
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     strategy:
       fail-fast: false 
       matrix:

--- a/spyder_kernels/utils/misc.py
+++ b/spyder_kernels/utils/misc.py
@@ -35,8 +35,13 @@ def is_module_installed(module_name):
     Simpler version of spyder.utils.programs.is_module_installed.
     """
     try:
-        __import__(module_name)
-        return True
+        mod = __import__(module_name)
+        # This is necessary to not report that the module is installed
+        # when only its __pycache__ directory is present.
+        if getattr(mod, '__file__', None):
+            return True
+        else:
+            return False
     except Exception:
         # Module is not installed
         return False


### PR DESCRIPTION
This is necessary to not report that a module is installed when it can imported but only its `__pycache__` directory is present (due to an incorrect uninstallation).