### PR TITLE
PR: Add spyder-kernels version to banner

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -21,6 +21,7 @@ from IPython.core.getipython import get_ipython
 
 from spyder_kernels.comms.commbase import CommBase, CommError
 from spyder_kernels.py3compat import TimeoutError, PY2
+from spyder_kernels import __version__ as spyder_kernels_version
 
 
 def get_free_port():
@@ -198,6 +199,7 @@ class FrontendComm(CommBase):
     def on_outgoing_call(self, call_dict):
         """A message is about to be sent"""
         call_dict["comm_port"] = self.comm_port
+        call_dict["spyder_kernels_version"] = spyder_kernels_version
         return super(FrontendComm, self).on_outgoing_call(call_dict)
 
     def _send_comm_config(self):

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -22,6 +22,7 @@ from ipykernel.ipkernel import IPythonKernel
 from ipykernel.zmqshell import ZMQInteractiveShell
 
 # Local imports
+from spyder_kernels import __version__
 from spyder_kernels.py3compat import TEXT_TYPES, to_text_string
 from spyder_kernels.comms.frontendcomm import FrontendComm
 from spyder_kernels.py3compat import PY3, input
@@ -53,6 +54,13 @@ class SpyderShell(ZMQInteractiveShell):
             return namespace
         else:
             return frame.f_locals
+
+    @property
+    def banner(self):
+        """Get banner."""
+        return (
+            "Spyder Kernels {version}".format(version=__version__)
+            + " -- Jupyter kernels for the Spyder console")
 
 
 class SpyderKernel(IPythonKernel):


### PR DESCRIPTION
The banner looks like:
```
Python 3.7.6 (default, Jan  8 2020, 20:23:39) [MSC v.1916 64 bit (AMD64)]
Type "copyright", "credits" or "license" for more information.

IPython 7.19.0 -- An enhanced Interactive Python.
Spyder Kernels 1.11.0.dev0 -- Jupyter kernels for the Spyder console

```