### PR TITLE
PR: Warn when comm call creates text output

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -13,7 +13,6 @@ import socket
 import sys
 import threading
 import time
-from io import TextIOBase
 
 from jupyter_client.localinterfaces import localhost
 from tornado import ioloop

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -13,6 +13,7 @@ import socket
 import sys
 import threading
 import time
+from io import TextIOBase
 
 from jupyter_client.localinterfaces import localhost
 from tornado import ioloop
@@ -229,3 +230,34 @@ class FrontendComm(CommBase):
                 comm._msg_callback(msg)
         comm.handle_msg = handle_msg
         super(FrontendComm, self)._register_comm(comm)
+
+    def _remote_callback(self, call_name, call_args, call_kwargs):
+        """Call the callback function for the remote call."""
+        saved_stdout_write = sys.stdout.write
+        saved_stderr_write = sys.stderr.write
+        sys.stdout.write = WriteWrapper(saved_stdout_write, call_name)
+        sys.stderr.write = WriteWrapper(saved_stderr_write, call_name)
+        try:
+            return super(FrontendComm, self)._remote_callback(
+                call_name, call_args, call_kwargs)
+        finally:
+            sys.stdout.write = saved_stdout_write
+            sys.stderr.write = saved_stderr_write
+
+
+class WriteWrapper():
+    """Wrapper to warn user when text is printed."""
+
+    def __init__(self, write, name):
+        self._write = write
+        self._name = name
+        self._warning_shown = False
+
+    def __call__(self, string):
+        """Print warning once."""
+        if not self._warning_shown:
+            self._warning_shown = True
+            self._write(
+                "\nOutput from spyder call "
+                + repr(self._name) + ":\n")
+        return self._write(string)


### PR DESCRIPTION
Addresses https://github.com/spyder-ide/spyder/issues/14551

```
In [1]: class A():
   ...:     @property
   ...:     def shape(self):
   ...:         print((1234, 1))
   ...:         return 1234, 1

In [2]: a = A()

Output from spyder call 'get_namespace_view':
(1234, 1)
(1234, 1)
(1234, 1)
(1234, 1)

In [3]: 
```