### PR TITLE
PR: Fix numpy.complex deprecation warning in tests

### DIFF
--- a/spyder_kernels/utils/tests/test_iofuncs.py
+++ b/spyder_kernels/utils/tests/test_iofuncs.py
@@ -87,7 +87,7 @@ def spydata_values():
     A = 1
     B = 'ham'
     C = np.eye(3)
-    D = {'a': True, 'b': np.eye(4, dtype=np.complex)}
+    D = {'a': True, 'b': np.eye(4, dtype=np.complex128)}
     E = [np.eye(2, dtype=np.int64), 42.0, np.eye(3, dtype=np.bool_)]
     return {'A': A, 'B': B, 'C': C, 'D': D, 'E': E}
 

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -67,7 +67,7 @@ def test_get_size():
     df = pd.Index([1,2,3])
     assert get_size(df) == (3,)
 
-    arr = np.array([[1,2,3], [1,2,3]], dtype=np.complex)
+    arr = np.array([[1,2,3], [1,2,3]], dtype=np.complex128)
     assert get_size(arr) == (2, 3)
 
     img = PIL.Image.new('RGB', (256,256))


### PR DESCRIPTION
While running the test suite under numpy 1.20, the following warning appears:
```
  /build/python-spyder-kernels/src/spyder-kernels-1.10.2/spyder_kernels/utils/tests/test_iofuncs.py:90: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    D = {'a': True, 'b': np.eye(4, dtype=np.complex)}

  /build/python-spyder-kernels/src/spyder-kernels-1.10.2/spyder_kernels/utils/tests/test_nsview.py:69: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    arr = np.array([[1,2,3], [1,2,3]], dtype=np.complex)
```

This commit fixes both instances.