### PR TITLE
PR: Remove handling of colors for object types

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -135,13 +135,25 @@ class SpyderKernel(IPythonKernel):
 
         This is a dictionary with the following structure
 
-        {'a': {'color': '#800000', 'size': 1, 'type': 'str', 'view': '1'}}
+        {'a':
+            {
+                'type': 'str',
+                'size': 1,
+                'view': '1',
+                'python_type': 'int',
+                'numpy_type': 'Unknown'
+            }
+        }
 
         Here:
-        * 'a' is the variable name
-        * 'color' is the color used to show it
-        * 'size' and 'type' are self-evident
-        * and'view' is its value or the text shown in the last column
+        * 'a' is the variable name.
+        * 'type' and 'size' are self-evident.
+        * 'view' is its value or its repr computed with
+          `value_to_display`.
+        * 'python_type' is its Python type computed with
+          `get_type_string`.
+        * 'numpy_type' is its Numpy type (if any) computed with
+          `get_numpy_type_string`.
         """
         from spyder_kernels.utils.nsview import make_remote_view
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -182,8 +182,13 @@ def test_get_namespace_view(kernel):
     assert "'a':" in nsview
     assert "'type': 'int'" in nsview or "'type': u'int'" in nsview
     assert "'size': 1" in nsview
-    assert "'color': '#0000ff'" in nsview
     assert "'view': '1'" in nsview
+    assert "'numpy_type': 'Unknown'" in nsview
+
+    if PY3:
+        assert "'python_type': 'int'" in nsview
+    else:
+        assert "'python_type': u'int'" in nsview
 
 
 def test_get_var_properties(kernel):

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -73,6 +73,17 @@ def get_numpy_dtype(obj):
                 return
 
 
+def get_numpy_type_string(value):
+    """Get the type of a Numpy object as a string."""
+    np_dtype = get_numpy_dtype(value)
+    if np_dtype is None or not hasattr(value, 'size'):
+        return 'Unknown'
+    elif value.size == 1:
+        return 'Scalar'
+    else:
+        return 'Array'
+
+
 #==============================================================================
 # Pandas support
 #==============================================================================
@@ -747,7 +758,8 @@ def make_remote_view(data, settings, more_excluded_names=None):
             'size':  get_size(value),
             'color': get_color_name(value),
             'view':  view,
-            'python_type': get_type_string(value)
+            'python_type': get_type_string(value),
+            'numpy_type': get_numpy_type_string(value)
         }
 
     return remote

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -221,48 +221,8 @@ def str_to_timedelta(value):
 
 
 #==============================================================================
-# Background colors for supported types
+# Supported types
 #==============================================================================
-ARRAY_COLOR = "#00ff00"
-SCALAR_COLOR = "#0000ff"
-COLORS = {
-          bool:               "#ff00ff",
-          NUMERIC_TYPES:      SCALAR_COLOR,
-          list:               "#ffff00",
-          set:                "#008000",
-          dict:               "#00ffff",
-          tuple:              "#c0c0c0",
-          TEXT_TYPES:         "#800000",
-          (ndarray,
-           MaskedArray,
-           matrix,
-           DataFrame,
-           Series,
-           Index):            ARRAY_COLOR,
-          Image:              "#008000",
-          datetime.date:      "#808000",
-          datetime.timedelta: "#808000",
-          }
-CUSTOM_TYPE_COLOR = "#7755aa"
-UNSUPPORTED_COLOR = "#ffffff"
-
-def get_color_name(value):
-    """Return color name depending on value type"""
-    if not is_known_type(value):
-        return CUSTOM_TYPE_COLOR
-    for typ, name in list(COLORS.items()):
-        if isinstance(value, typ):
-            return name
-    else:
-        np_dtype = get_numpy_dtype(value)
-        if np_dtype is None or not hasattr(value, 'size'):
-            return UNSUPPORTED_COLOR
-        elif value.size == 1:
-            return SCALAR_COLOR
-        else:
-            return ARRAY_COLOR
-
-
 def is_editable_type(value):
     """
     Return True if data type is editable with a standard GUI-based editor,
@@ -756,7 +716,6 @@ def make_remote_view(data, settings, more_excluded_names=None):
         remote[key] = {
             'type':  get_human_readable_type(value),
             'size':  get_size(value),
-            'color': get_color_name(value),
             'view':  view,
             'python_type': get_type_string(value),
             'numpy_type': get_numpy_type_string(value)

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -22,10 +22,11 @@ import PIL.Image
 
 # Local imports
 from spyder_kernels.py3compat import PY2
-from spyder_kernels.utils.nsview import (sort_against, is_supported,
-                                         value_to_display, get_size,
-                                         get_supported_types, get_type_string,
-                                         is_editable_type)
+from spyder_kernels.utils.nsview import (
+    sort_against, is_supported, value_to_display, get_size,
+    get_supported_types, get_type_string, get_numpy_type_string,
+    is_editable_type)
+
 
 def generate_complex_object():
     """Taken from issue #4221."""
@@ -419,6 +420,30 @@ def test_is_editable_type():
 
     my_instance = MyClass()
     assert not is_editable_type(my_instance)
+
+
+def test_get_numpy_type():
+    """Test for get_numpy_type_string."""
+    # Numpy objects
+    assert get_numpy_type_string(np.array([1, 2, 3])) == 'Array'
+
+    matrix = np.matrix([[1, 2], [3, 4]])
+    assert get_numpy_type_string(matrix) == 'Array'
+
+    assert get_numpy_type_string(np.int32(1)) == 'Scalar'
+
+    # Regular Python objects
+    assert get_numpy_type_string(1.5) == 'Unknown'
+    assert get_numpy_type_string([1, 2, 3]) == 'Unknown'
+    assert get_numpy_type_string({1: 2}) == 'Unknown'
+
+    # PIL images
+    img = PIL.Image.new('RGB', (256,256))
+    assert get_numpy_type_string(img) == 'Unknown'
+
+    # Pandas objects
+    df = pd.DataFrame([1, 2, 3])
+    assert get_numpy_type_string(df) == 'Unknown'
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- That will be handled by Spyder instead.
- This also adds Numpy types to the namespace view, which are necessary for that purpose.