### PR TITLE
PR: Add a new dependency on decorator to fix the Cython magic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ def get_version(module='spyder_kernels'):
 
 REQUIREMENTS = [
     'cloudpickle',
+    'decorator<5',  # Higher versions break the Cython magic
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',


### PR DESCRIPTION
- Unfortunately `decorator` 5.0 breaks the Cython magic.
- This is tested on the Spyder side, not here.