### PR TITLE
PR: Fix setting tight layout in inline figures

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -20,6 +20,7 @@ import threading
 import ipykernel
 from ipykernel.ipkernel import IPythonKernel
 from ipykernel.zmqshell import ZMQInteractiveShell
+from traitlets.config.loader import LazyConfigValue
 
 # Local imports
 from spyder_kernels.py3compat import TEXT_TYPES, to_text_string
@@ -456,7 +457,7 @@ class SpyderKernel(IPythonKernel):
         """
         Set inline print figure bbox inches.
 
-        The change is done by updating the ´rint_figure_kwargs' config dict.
+        The change is done by updating the 'print_figure_kwargs' config dict.
         """
         from IPython.core.getipython import get_ipython
         config = get_ipython().kernel.config
@@ -468,6 +469,14 @@ class SpyderKernel(IPythonKernel):
         bbox_inches_dict = {
             'bbox_inches': 'tight' if bbox_inches else None}
         print_figure_kwargs.update(bbox_inches_dict)
+
+        # This seems to be necessary for newer versions of Traitlets because
+        # print_figure_kwargs doesn't return a dict.
+        if isinstance(print_figure_kwargs, LazyConfigValue):
+            figure_kwargs_dict = print_figure_kwargs.to_dict().get('update')
+            if figure_kwargs_dict:
+                print_figure_kwargs = figure_kwargs_dict
+
         self._set_config_option(
             'InlineBackend.print_figure_kwargs', print_figure_kwargs)
 


### PR DESCRIPTION
This was failing probably since the release of Traitlets 5.