### PR TITLE
PR: Add constraints on IPython and ipykernel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIREMENTS = [
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',
-    'ipython>=7.6.0; python_version>="3"',
+    'ipython>=7.6.0,<7.23.0; python_version>="3"',
     'jupyter-client>=5.3.4',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def get_version(module='spyder_kernels'):
 REQUIREMENTS = [
     'cloudpickle',
     'ipykernel<5; python_version<"3"',
-    'ipykernel>=5.3.0; python_version>="3"',
+    'ipykernel>=5.3.0,<6.0.0; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0,<7.23.0; python_version>="3"',
     'jupyter-client>=5.3.4',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,6 @@ def get_version(module='spyder_kernels'):
 
 REQUIREMENTS = [
     'cloudpickle',
-    'decorator<5',  # Higher versions break the Cython magic
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',


### PR DESCRIPTION
- IPython 7.23 breaks the inline backend
- ipykernel 6 could break us because it comes with a lot of changes
- I removed the pin on decorator < 5 because the Cython magic doesn't fail with it anymore.