### PR TITLE
PR: Install click 7 to run our tests in Python 2

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -45,6 +45,7 @@ jobs:
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
           if [ "$PYTHON_VERSION" != "2.7" ]; then conda install -y -q jedi=0.17.2; fi
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -41,6 +41,7 @@ jobs:
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
           if [ "$PYTHON_VERSION" != "2.7" ]; then conda install -y -q jedi=0.17.2; fi
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .


### PR DESCRIPTION
Conda is incorrectly installing click 8 and that's breaking our tests.