### PR TITLE
PR: Fix recursive debugger

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -511,7 +511,19 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         argument (which is an arbitrary expression or statement to be
         executed in the current environment).
         """
-        super(SpyderPdb, self).do_debug(arg)
+        try:
+            super(SpyderPdb, self).do_debug(arg)
+        except Exception:
+            if PY2:
+                t, v = sys.exc_info()[:2]
+                if type(t) == type(''):
+                    exc_type_name = t
+                else: exc_type_name = t.__name__
+                print >>self.stdout, '***', exc_type_name + ':', v
+            else:
+                exc_info = sys.exc_info()[:2]
+                self.error(
+                    traceback.format_exception_only(*exc_info)[-1].strip())
         kernel = get_ipython().kernel
         kernel._register_pdb_session(self)
 


### PR DESCRIPTION
Handle a case where an invalid line is passed to the recursive debug.

From:

``` python
In [1]: %debug print()
NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
> <string>(1)<module>()


IPdb [1]: debug ab
ENTERING RECURSIVE DEBUGGER
> <string>(1)<module>()


(IPdb [1]): c
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "<string>", line 1, in <module>
  File "C:\ProgramData\Anaconda3\lib\bdb.py", line 88, in trace_dispatch
    return self.dispatch_line(frame)
  File "C:\ProgramData\Anaconda3\lib\bdb.py", line 112, in dispatch_line
    self.user_line(frame)
  File "C:\ProgramData\Anaconda3\lib\pdb.py", line 262, in user_line
    self.interaction(frame, None)
  File "c:\users\quentin.peter\spyder-kernels\spyder_kernels\customize\spyderpdb.py", line 235, in interaction
    self._cmdloop()
  File "c:\users\quentin.peter\spyder-kernels\spyder_kernels\customize\spyderpdb.py", line 536, in _cmdloop
    self.cmdloop()
  File "C:\ProgramData\Anaconda3\lib\cmd.py", line 138, in cmdloop
    stop = self.onecmd(line)
  File "C:\ProgramData\Anaconda3\lib\pdb.py", line 423, in onecmd
    return cmd.Cmd.onecmd(self, line)
  File "C:\ProgramData\Anaconda3\lib\cmd.py", line 206, in onecmd
    return self.default(line)
  File "c:\users\quentin.peter\spyder-kernels\spyder_kernels\customize\spyderpdb.py", line 163, in default
    return cmd_func(arg)
  File "c:\users\quentin.peter\spyder-kernels\spyder_kernels\customize\spyderpdb.py", line 514, in do_debug
    super(SpyderPdb, self).do_debug(arg)
  File "C:\ProgramData\Anaconda3\lib\site-packages\IPython\core\debugger.py", line 609, in do_debug
    sys.call_tracing(p.run, (arg, globals, locals))
  File "c:\users\quentin.peter\spyder-kernels\spyder_kernels\customize\spyderpdb.py", line 700, in run
    super(SpyderPdb, self).run(cmd, globals, locals)
  File "C:\ProgramData\Anaconda3\lib\bdb.py", line 580, in run
    exec(cmd, globals, locals)
  File "<string>", line 1, in <module>
NameError: name 'ab' is not defined


In [2]: 
```

To:

``` python
In [2]: %debug print()
NOTE: Enter 'c' at the ipdb>  prompt to continue execution.
> <string>(1)<module>()


IPdb [1]: debug ab
ENTERING RECURSIVE DEBUGGER
> <string>(1)<module>()


(IPdb [1]): c
*** NameError: name 'ab' is not defined

IPdb [2]: 
```

Notice we are back to the first debug level instead of dropping out completely.