### PR TITLE
PR: Don't report skipped frames for IPython 7.24+ (Debugger)

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -15,8 +15,8 @@ import traceback
 from collections import namedtuple
 
 from IPython.core.autocall import ZMQExitAutocall
-from IPython.core.getipython import get_ipython
 from IPython.core.debugger import Pdb as ipyPdb
+from IPython.core.getipython import get_ipython
 
 from spyder_kernels.comms.frontendcomm import CommError, frontend_request
 from spyder_kernels.customize.utils import path_is_library
@@ -91,6 +91,10 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         super(SpyderPdb, self).__init__()
         self._pdb_breaking = False
         self._frontend_notified = False
+
+        # Don't report hidden frames for IPython 7.24+. This attribute
+        # has no effect in previous versions.
+        self.report_skipped = False
 
     # --- Methods overriden for code execution
     def print_exclamation_warning(self):


### PR DESCRIPTION
With this we can maintain the previous behavior (of not showing a message for skipped frames) by using a new attribute added to IPdb in IPython 7.24.1