### PR TITLE
PR: Use an outstream with isatty() equal to True

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ REQUIREMENTS = [
     'ipython>=7.6.0; python_version>="3"',
     'jupyter-client>=5.3.4',
     'pyzmq>=17',
+    'traitlets'
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ REQUIREMENTS = [
     'ipython>=7.6.0; python_version>="3"',
     'jupyter-client>=5.3.4',
     'pyzmq>=17',
-    'traitlets'
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 

--- a/spyder_kernels/console/outstream.py
+++ b/spyder_kernels/console/outstream.py
@@ -12,6 +12,6 @@ Custom Spyder Outstream class.
 
 from ipykernel.iostream import OutStream
 class TTYOutStream(OutStream):
-        """ Subclass of OutStream that represents a TTY """
+        """Subclass of OutStream that represents a TTY."""
         def __init__(self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True):
             super().__init__(session, pub_thread, name, pipe, echo=echo,  watchfd=watchfd, isatty=True)

--- a/spyder_kernels/console/outstream.py
+++ b/spyder_kernels/console/outstream.py
@@ -11,7 +11,11 @@ Custom Spyder Outstream class.
 """
 
 from ipykernel.iostream import OutStream
+
+
 class TTYOutStream(OutStream):
-        """Subclass of OutStream that represents a TTY."""
-        def __init__(self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True):
-            super().__init__(session, pub_thread, name, pipe, echo=echo,  watchfd=watchfd, isatty=True)
+    """Subclass of OutStream that represents a TTY."""
+
+    def __init__(self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True):
+        super().__init__(session, pub_thread, name, pipe,
+                         echo=echo, watchfd=watchfd, isatty=True)

--- a/spyder_kernels/console/outstream.py
+++ b/spyder_kernels/console/outstream.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) 2009- Spyder Kernels Contributors
+#
+# Licensed under the terms of the MIT License
+# (see spyder_kernels/__init__.py for details)
+# -----------------------------------------------------------------------------
+
+"""
+Custom Spyder Outstream class.
+"""
+
+from ipykernel.iostream import OutStream
+class TTYOutStream(OutStream):
+        """ Subclass of OutStream that represents a TTY """
+        def __init__(self, session, pub_thread, name, pipe=None, echo=None, *, watchfd=True):
+            super().__init__(session, pub_thread, name, pipe, echo=echo,  watchfd=watchfd, isatty=True)

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -271,7 +271,8 @@ def main():
 
     class SpyderKernelApp(IPKernelApp):
 
-        outstream_class = DottedObjectName('spyder_kernels.console.outstream.TTYOutStream', help="The importstring for the OutStream factory").tag(config=True)
+        outstream_class = DottedObjectName(
+            'spyder_kernels.console.outstream.TTYOutStream')
 
         def init_pdb(self):
             """

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -240,7 +240,6 @@ def varexp(line):
     pyplot.show()
     del __fig__, __items__
 
-print('import spyder_kernels.console.start')
 
 def main():
     # Remove this module's path from sys.path:
@@ -285,7 +284,6 @@ def main():
 
     # Fire up the kernel instance.
     kernel = SpyderKernelApp.instance()
-    #kernel.outstream_class = DottedObjectName('spyder_kernels.console.outstream.TTYOutStream', help="The importstring for the OutStream factory").tag(config=True)
     kernel.kernel_class = SpyderKernel
     try:
         kernel.config = kernel_config()

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -18,6 +18,7 @@ import sys
 import site
 
 from traitlets import DottedObjectName
+import ipykernel
 
 # Local imports
 from spyder_kernels.utils.misc import (
@@ -25,6 +26,8 @@ from spyder_kernels.utils.misc import (
 
 
 PY2 = sys.version[0] == '2'
+IPYKERNEL_6 = ipykernel.__version__[0] >= '6'
+
 
 
 def import_spydercustomize():
@@ -271,8 +274,9 @@ def main():
 
     class SpyderKernelApp(IPKernelApp):
 
-        outstream_class = DottedObjectName(
-            'spyder_kernels.console.outstream.TTYOutStream')
+        if IPYKERNEL_6:
+            outstream_class = DottedObjectName(
+                'spyder_kernels.console.outstream.TTYOutStream')
 
         def init_pdb(self):
             """

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -17,6 +17,8 @@ import os.path as osp
 import sys
 import site
 
+from traitlets import DottedObjectName
+
 # Local imports
 from spyder_kernels.utils.misc import (
     MPL_BACKENDS_FROM_SPYDER, INLINE_FIGURE_FORMATS, is_module_installed)
@@ -238,6 +240,7 @@ def varexp(line):
     pyplot.show()
     del __fig__, __items__
 
+print('import spyder_kernels.console.start')
 
 def main():
     # Remove this module's path from sys.path:
@@ -269,6 +272,8 @@ def main():
 
     class SpyderKernelApp(IPKernelApp):
 
+        outstream_class = DottedObjectName('spyder_kernels.console.outstream.TTYOutStream', help="The importstring for the OutStream factory").tag(config=True)
+
         def init_pdb(self):
             """
             This method was added in IPykernel 5.3.1 and it replaces
@@ -280,6 +285,7 @@ def main():
 
     # Fire up the kernel instance.
     kernel = SpyderKernelApp.instance()
+    #kernel.outstream_class = DottedObjectName('spyder_kernels.console.outstream.TTYOutStream', help="The importstring for the OutStream factory").tag(config=True)
     kernel.kernel_class = SpyderKernel
     try:
         kernel.config = kernel_config()


### PR DESCRIPTION
This PR is work to enable colored output (by default) in the Spyder console. See https://github.com/spyder-ide/spyder/issues/1917, https://github.com/willmcgugan/rich/pull/1221, https://github.com/ipython/ipykernel/pull/683

Fixes #302

It adds `traitlets` as a new requirement, but since `ipykernel` already has this as a requirement this should have little impact.

@ccordoba12 