### PR TITLE
PR: Restrict jupyter-client to be less than version 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIREMENTS = [
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0; python_version>="3"',
-    'jupyter-client>=5.3.4',
+    'jupyter-client>=5.3.4,<7',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
@@ -91,6 +91,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Interpreters',
     ]
 )


### PR DESCRIPTION
- This is until we find the time to figure out how to support it.
- Also add Python 3.9 classifier.