### PR TITLE
PR: Memoize results of is_module_installed

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -38,13 +38,14 @@ jobs:
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
-        run: conda install --file requirements/posix.txt -y -q
+        run: |
+          conda install --file requirements/posix.txt -y -q
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -34,13 +34,14 @@ jobs:
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
-        run: conda install --file requirements/posix.txt -y -q
+        run: |
+          conda install --file requirements/posix.txt -y -q
+          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
           conda install nomkl -y -q
           conda install --file requirements/tests.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install -y -q click=7; fi
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/requirements/python-27.txt
+++ b/requirements/python-27.txt
@@ -1,0 +1,2 @@
+click =7
+backports.functools_lru_cache

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ def get_version(module='spyder_kernels'):
 
 
 REQUIREMENTS = [
+    'backports.functools-lru-cache; python_version<"3"',
     'cloudpickle',
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',

--- a/spyder_kernels/py3compat.py
+++ b/spyder_kernels/py3compat.py
@@ -258,6 +258,7 @@ if PY2:
     import string
     str_lower = string.lower
     from itertools import izip_longest as zip_longest
+    from backports.functools_lru_cache import lru_cache
 else:
     # Python 3
     getcwd = os.getcwd
@@ -265,6 +266,7 @@ else:
         return (a > b) - (a < b)
     str_lower = str.lower
     from itertools import zip_longest
+    from functools import lru_cache
 
 def qbytearray_to_str(qba):
     """Convert QByteArray object to str in a way compatible with Python 2/3"""

--- a/spyder_kernels/utils/misc.py
+++ b/spyder_kernels/utils/misc.py
@@ -10,7 +10,10 @@
 
 import re
 
+from spyder_kernels.py3compat import lru_cache
 
+
+@lru_cache(maxsize=100)
 def is_module_installed(module_name):
     """
     Simpler version of spyder.utils.programs.is_module_installed.


### PR DESCRIPTION
- This avoids having to call repeatedly that function when computing lazy modules attributes.
- Addresses spyder-ide/spyder#16247