### PR TITLE
PR: Remove dependency on ipython_genutils

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -27,7 +27,6 @@ import pytest
 from flaky import flaky
 from jupyter_core import paths
 from jupyter_client import BlockingKernelClient
-from ipython_genutils import py3compat
 import numpy as np
 
 # Local imports
@@ -77,7 +76,8 @@ def setup_kernel(cmd):
 
         if kernel.poll() is not None:
             o,e = kernel.communicate()
-            e = py3compat.cast_unicode(e)
+            if not PY3 and isinstance(e, bytes):
+                e = e.decode()
             raise IOError("Kernel failed to start:\n%s" % e)
 
         if not os.path.exists(connection_file):


### PR DESCRIPTION
It requires nose in test suite, that is not package on many linux distrib
and should not be used anymore.

Technically this change is a bit more conservative than what genutils
was doing when trying to detect the default encoding, but that should
not matter much now.

---

Redo of #311 that auto closed for I'm not too sure which reason from @ccordoba12  comment there I've also  send the PR against the 2.x  branch if my understanding of the workflow is correct.