### PR TITLE
PR: Avoid runfile to be shadowed by other packages

### DIFF
--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -46,7 +46,7 @@ def import_spydercustomize():
 
     # Import our customizations
     site.addsitedir(customize_dir)
-    import spydercustomize
+    import spydercustomize  # noqa
 
     # Remove our customize path from sys.path
     try:
@@ -109,8 +109,17 @@ def kernel_config():
     # Spyder, to avoid deleting the sys module if users want to import
     # it through them.
     # See spyder-ide/spyder#15788
-    clear_argv = "import sys;sys.argv = [''];del sys"
+    clear_argv = "import sys; sys.argv = ['']; del sys"
     spy_cfg.IPKernelApp.exec_lines = [clear_argv]
+
+    # Set our runfile in builtins here to prevent other packages shadowing it.
+    # This started to be a problem since IPykernel 6.3.0.
+    if not PY2:
+        spy_cfg.IPKernelApp.exec_lines.append(
+            "import builtins; "
+            "builtins.runfile = builtins.spyder_runfile; "
+            "del builtins.spyder_runfile; del builtins"
+        )
 
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -580,7 +580,13 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         sys.argv = ['']
 
 
-builtins.runfile = runfile
+# IPykernel 6.3.0+ shadows our runfile because it depends on the Pydev
+# debugger, which adds its own runfile to builtins. So we replace it with
+# our own using exec_lines in start.py
+if PY2:
+    builtins.runfile = runfile
+else:
+    builtins.spyder_runfile = runfile
 
 
 def debugfile(filename=None, args=None, wdir=None, post_mortem=False,


### PR DESCRIPTION
- Other packages (e.g. the Pydev debugger) can also add a `runfile` function to `builtins`, which prevents using our own.
- This started to be a problem since IPykernel 6.3.0.