### PR TITLE
PR: Prevent other libraries to change the breakpoint builtin

### DIFF
--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -121,6 +121,15 @@ def kernel_config():
             "del builtins.spyder_runfile; del builtins"
         )
 
+    # Prevent other libraries to change the breakpoint builtin.
+    # This started to be a problem since IPykernel 6.3.0.
+    if sys.version_info[0:2] >= (3, 7):
+        spy_cfg.IPKernelApp.exec_lines.append(
+            "import sys; import pdb; "
+            "sys.breakpointhook = pdb.set_trace; "
+            "del sys; del pdb"
+        )
+
     # Run lines of code at startup
     run_lines_o = os.environ.get('SPY_RUN_LINES_O')
     if run_lines_o is not None:


### PR DESCRIPTION
That builtin was overridden by `pydevd`, now used in IPykernel by default.