### PR TITLE
PR: Add `ipython_genutils` dependency for testing

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -11,3 +11,5 @@ pytest-cov
 scipy
 xarray
 pillow
+# Remove when Anaconda updates to a newer ipykernel
+ipython_genutils


### PR DESCRIPTION
- This helps to fix our tests because the current IPykernel package in Anaconda doesn't have a declared dependency in `ipython_genutils`.
- We don't need to declare that dependency here because it was fixed in IPykernel **6.3.1**.