### PR TITLE
PR: Remove upper constraint on jupyter_client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ REQUIREMENTS = [
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0; python_version>="3"',
-    'jupyter-client>=5.3.4,<7',
+    'jupyter-client>=5.3.4',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]


### PR DESCRIPTION
According to the [migration guide](https://jupyter-client.readthedocs.io/en/master/migration.html), removing the `block` parameter should be all that is needed here. Let's see...