### PR TITLE
PR: Implement a less hacky solution to fix namespace issues

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1041,10 +1041,6 @@ def test_locals_globals_in_pdb(kernel):
         'test = "a" in locals()')
     assert kernel.get_value('test') == True
 
-    kernel.shell.pdb_session.default(
-        'test = f()')
-    assert kernel.get_value('test') == 2
-
     pdb_obj.curframe = None
     pdb_obj.curframe_locals = None
 

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -177,7 +177,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 
                 if locals is not globals:
                     # Mitigates a behaviour of CPython that makes it difficult
-                    # To work with exec and the local namespace
+                    # to work with exec and the local namespace
                     # See:
                     #  - https://bugs.python.org/issue41918
                     #  - https://bugs.python.org/issue46153
@@ -204,19 +204,22 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                     except SyntaxError:
                         pass
 
-                    # create a function and load the locals
+                    # Create a function and load the locals
                     globals["_spyderpdb_locals"] = locals
                     indent = "    "
                     code = ["def _spyderpdb_code():"]
                     code += [indent + "{k} = _spyderpdb_locals['{k}']".format(
                         k=k) for k in locals]
+
                     # Run the code
                     if print_ret:
                         code += [indent + 'print(' + line.strip() + ")"]
                     else:
                         code += [indent + l for l in line.splitlines()]
+
                     # Update the locals
                     code += [indent + "_spyderpdb_locals.update(locals())"]
+
                     # Run the function
                     code += ["_spyderpdb_code()"]
                     code = compile('\n'.join(code) + '\n', '<stdin>', 'exec')
@@ -229,7 +232,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                     try:
                         code = compile(line + '\n', '<stdin>', 'single')
                     except SyntaxError:
-                        # support multiline statments
+                        # Support multiline statments
                         code = compile(line + '\n', '<stdin>', 'exec')
                     exec(code, globals)
             finally:

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -210,7 +210,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                     code = [
                         "def _spyder_pdb_code():",]
                     code += [
-                        indent + f"{k} = _get_spyderpdb_locals()['{k}']"
+                        indent + "{k} = _get_spyderpdb_locals()['{k}']".format(k=k)
                         for k in locals]
                     # Run the code
                     if print_ret:


### PR DESCRIPTION
@ccordoba12 
Sorry for changing my mind. This is a less hacky version of https://github.com/spyder-ide/spyder-kernels/pull/351. I am more confident that this won't create subtle bugs. The only problem with this approach I could think of is that closures defined in the pdb prompt are early binding. This removes the difference between `globals()` and `frame.f_globals` that might have been problematic.