### PR TITLE
PR: Constraint IPython version to avoid issues when its next major version is released

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,3 +1,4 @@
 cloudpickle
 ipykernel
 wurlitzer>=1.0.3
+ipython<8

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -2,3 +2,4 @@ cloudpickle
 ipykernel
 # Pin pip version since we are getting 9.x and it causes IPython 6.1.0 to be installed
 pip>=19.3.1
+ipython<8

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIREMENTS = [
     'ipykernel<5; python_version<"3"',
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',
-    'ipython>=7.6.0; python_version>="3"',
+    'ipython>=7.6.0,<8; python_version>="3"',
     'jupyter-client>=5.3.4',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',


### PR DESCRIPTION
We require now `ipython >=7.6.0,<8`