### PR TITLE
PR: Increase minimal required version of jupyter_client to 7.0+ for Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ REQUIREMENTS = [
     'ipykernel>=5.3.0; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0,<8; python_version>="3"',
-    'jupyter-client>=5.3.4',
+    'jupyter-client>=5.3.4,<6; python_version<"3"',
+    'jupyter-client>=7.0.0; python_version>="3"',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]


### PR DESCRIPTION
This is necessary to work with its new async codebase in Spyder, which is completely different from the one in previous versions.