### PR TITLE
PR: Require jupyter-client 7.1.0 to fix issues on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ REQUIREMENTS = [
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',
-    'jupyter-client>=7.0.0; python_version>="3"',
+    'jupyter-client>=7.1.0; python_version>="3"',
     'pyzmq>=17',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]


### PR DESCRIPTION
- In particular, this should fix `ZMQError: Address already in use` when restarting the kernel.
- Addresses spyder-ide/spyder#14739.