### PR TITLE
PR: Increase minimal required version of ipykernel to 6.6.1

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9']
+    timeout-minutes: 10
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
@@ -35,17 +36,16 @@ jobs:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
+           channels: conda-forge
+           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          conda install --file requirements/posix.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
+          if [ "$PYTHON_VERSION" != "2.7" ]; then mamba install --file requirements/posix.txt -y -q; else mamba install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
-        run: |
-          conda install nomkl -y -q
-          conda install --file requirements/tests.txt -y -q
+        run: mamba install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         PYTHON_VERSION: ['2.7', '3.7', '3.8', '3.9']
+    timeout-minutes: 10
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
@@ -31,17 +32,16 @@ jobs:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
+           channels: conda-forge
+           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }} 
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          conda install --file requirements/posix.txt -y -q
-          if [ "$PYTHON_VERSION" = "2.7" ]; then conda install --file requirements/python-27.txt -y -q; fi
+          if [ "$PYTHON_VERSION" != "2.7" ]; then mamba install --file requirements/posix.txt -y -q; else mamba install --file requirements/python-27.txt -y -q; fi
       - name: Install test dependencies
         shell: bash -l {0}
-        run: |
-          conda install nomkl -y -q
-          conda install --file requirements/tests.txt -y -q
+        run: mamba install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false 
       matrix:
         PYTHON_VERSION: ['3.7', '3.8', '3.9']
+    timeout-minutes: 10
     steps:
       - name: Checkout branch
         uses: actions/checkout@v1
@@ -31,14 +32,16 @@ jobs:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
+           channels: conda-forge
+           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
-        run: conda install --file requirements/windows.txt -y -q
+        run: mamba install --file requirements/windows.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
-          conda install --file requirements/tests.txt -y -q
+          mamba install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,4 +1,6 @@
 cloudpickle
-ipykernel
+ipykernel>=6.6.1
+ipython>=7.6.0,<8
+jupyter_client>=7.1.0
+pyzmq>=17
 wurlitzer>=1.0.3
-ipython<8

--- a/requirements/python-27.txt
+++ b/requirements/python-27.txt
@@ -1,2 +1,9 @@
-click =7
+decorator<5
 backports.functools_lru_cache
+cloudpickle
+ipykernel<5
+jupyter_client>=5.3.4,<6
+pyzmq>=17
+wurlitzer>=1.0.3
+# To avoid an error with conda
+click =7

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,7 @@
 cloudpickle
-ipykernel
+ipykernel>=6.6.1
+ipython>=7.6.0,<8
+jupyter_client>=7.1.0
+pyzmq>=17
 # Pin pip version since we are getting 9.x and it causes IPython 6.1.0 to be installed
 pip>=19.3.1
-ipython<8

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIREMENTS = [
     'backports.functools-lru-cache; python_version<"3"',
     'cloudpickle',
     'ipykernel<5; python_version<"3"',
-    'ipykernel>=5.3.0; python_version>="3"',
+    'ipykernel>=6.6.1; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.6.0,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',


### PR DESCRIPTION
- This fixes a bug with the Tk backend.
- Explicitly declare all our deps in the requirements files used for testing.
- Switch to conda-forge for testing because it's much more up to date.