### PR TITLE
PR: Increase minimal required version of pyzmq for Python 3

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -2,5 +2,5 @@ cloudpickle
 ipykernel>=6.6.1
 ipython>=7.6.0,<8
 jupyter_client>=7.1.0
-pyzmq>=17
+pyzmq>=22.1.0
 wurlitzer>=1.0.3

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -2,6 +2,6 @@ cloudpickle
 ipykernel>=6.6.1
 ipython>=7.6.0,<8
 jupyter_client>=7.1.0
-pyzmq>=17
+pyzmq>=22.1.0
 # Pin pip version since we are getting 9.x and it causes IPython 6.1.0 to be installed
 pip>=19.3.1

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ REQUIREMENTS = [
     'ipython>=7.6.0,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',
     'jupyter-client>=7.1.0; python_version>="3"',
-    'pyzmq>=17',
+    'pyzmq>=17,<20; python_version<"3"',
+    'pyzmq>=22.1.0; python_version>="3"',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 


### PR DESCRIPTION
This avoids a crash at startup in Spyder when using older versions.