### PR TITLE
PR: Catch KeyError when closing comm

### DIFF
--- a/requirements/python-27.txt
+++ b/requirements/python-27.txt
@@ -3,7 +3,7 @@ backports.functools_lru_cache
 cloudpickle
 ipykernel<5
 jupyter_client>=5.3.4,<6
-pyzmq>=17
+pyzmq>=17,<20
 wurlitzer>=1.0.3
 # To avoid an error with conda
 click =7

--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -170,8 +170,11 @@ class CommBase(object):
         id_list = self.get_comm_id_list(comm_id)
 
         for comm_id in id_list:
-            self._comms[comm_id]['comm'].close()
-            del self._comms[comm_id]
+            try:
+                self._comms[comm_id]['comm'].close()
+                del self._comms[comm_id]
+            except KeyError:
+                pass
 
     def is_open(self, comm_id=None):
         """Check to see if the comm is open."""


### PR DESCRIPTION
- This error is shown in the console sometimes but it doesn't add any important information to users.
- See spyder-ide/spyder#17042 for the details.