### PR TITLE
PR: Catch error when validating if an object is defined in the namespace

### DIFF
--- a/spyder_kernels/utils/dochelpers.py
+++ b/spyder_kernels/utils/dochelpers.py
@@ -315,7 +315,7 @@ def isdefined(obj, force_import=False, namespace=None):
     for attr in attr_list:
         try:
             attr_not_found = not hasattr(eval(base, namespace), attr)
-        except (SyntaxError, AttributeError):
+        except (AttributeError, SyntaxError, TypeError):
             return False
         if attr_not_found:
             if force_import:


### PR DESCRIPTION
- See spyder-ide/spyder#17144