### PR TITLE
PR: Improve error message when setting a Matplotlib backend whose module is not present

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -271,7 +271,7 @@ class FrontendComm(CommBase):
             sys.stderr.write = saved_stderr_write
 
 
-class WriteWrapper():
+class WriteWrapper(object):
     """Wrapper to warn user when text is printed."""
 
     def __init__(self, write, name):
@@ -296,7 +296,12 @@ class WriteWrapper():
         if not self.is_benign_message(string):
             if not self._warning_shown:
                 self._warning_shown = True
-                self._write(
-                    "\nOutput from spyder call "
-                    + repr(self._name) + ":\n")
+
+                # Don't print handler name for `show_mpl_backend_errors`
+                # because we have a specific message for it.
+                if repr(self._name) != "'show_mpl_backend_errors'":
+                    self._write(
+                        "\nOutput from spyder call " + repr(self._name) + ":\n"
+                    )
+
             return self._write(string)

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -740,6 +740,15 @@ class SpyderKernel(IPythonKernel):
             # This covers other RuntimeError's
             else:
                 error = generic_error.format(traceback.format_exc())
+        except ImportError as err:
+            additional_info = (
+                "This is most likely caused by missing packages in the Python "
+                "environment\n"
+                "or installation whose interpreter is located at:\n\n"
+                "    {0}"
+            ).format(sys.executable)
+
+            error = generic_error.format(err) + '\n\n' + additional_info
         except Exception:
             error = generic_error.format(traceback.format_exc())
 


### PR DESCRIPTION
Before we were showing this very long message, which is not very telling

![imagen](https://user-images.githubusercontent.com/365293/149246884-de8a3629-6b33-46fd-89ee-99934c584daa.png)

Now we show this

![imagen](https://user-images.githubusercontent.com/365293/149247316-053bbc65-aa9a-4096-8741-b032fc3bdbdf.png)

Fixes #347.