### PR TITLE
PR: Increase minimal required IPython version to 7.31.1

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.6.1
-ipython>=7.6.0,<8
+ipython>=7.31.1,<8
 jupyter_client>=7.1.0
 pyzmq>=22.1.0
 wurlitzer>=1.0.3

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -11,5 +11,3 @@ pytest-cov
 scipy
 xarray
 pillow
-# Remove when Anaconda updates to a newer ipykernel
-ipython_genutils

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,7 +1,5 @@
 cloudpickle
 ipykernel>=6.6.1
-ipython>=7.6.0,<8
+ipython>=7.31.1,<8
 jupyter_client>=7.1.0
 pyzmq>=22.1.0
-# Pin pip version since we are getting 9.x and it causes IPython 6.1.0 to be installed
-pip>=19.3.1

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ REQUIREMENTS = [
     'ipykernel<5; python_version<"3"',
     'ipykernel>=6.6.1; python_version>="3"',
     'ipython<6; python_version<"3"',
-    'ipython>=7.6.0,<8; python_version>="3"',
+    'ipython>=7.31.1,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',
     'jupyter-client>=7.1.0; python_version>="3"',
     'pyzmq>=17,<20; python_version<"3"',


### PR DESCRIPTION
- That version addresses CVE-2022-21699
- This automatically drops support for Python 3.6

Fixes #344 