### PR TITLE
PR: Append paths that come from Spyder's Python path manager to the end of `sys.path`

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -641,7 +641,10 @@ class SpyderKernel(IPythonKernel):
             if active:
                 sys.path.insert(0, path)
                 pythonpath.insert(0, path)
-        os.environ.update({'PYTHONPATH': os.pathsep.join(pythonpath)})
+        if pythonpath:
+            os.environ.update({'PYTHONPATH': os.pathsep.join(pythonpath)})
+        else:
+            os.environ.pop('PYTHONPATH', None)
 
     # -- Private API ---------------------------------------------------
     # --- For the Variable Explorer

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -634,11 +634,14 @@ class SpyderKernel(IPythonKernel):
                 sys.path.remove(path)
 
         # Add new paths
-        # We do this in reverse order as we use `sys.path.insert(1, path)`.
+        # We do this in reverse order as we use `sys.path.insert(0, path)`.
         # This ensures the end result has the correct path order.
+        pythonpath = []
         for path, active in reversed(new_path_dict.items()):
             if active:
-                sys.path.insert(1, path)
+                sys.path.insert(0, path)
+                pythonpath.insert(0, path)
+        os.environ.update({'PYTHONPATH': os.pathsep.join(pythonpath)})
 
     # -- Private API ---------------------------------------------------
     # --- For the Variable Explorer

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -634,15 +634,10 @@ class SpyderKernel(IPythonKernel):
                 sys.path.remove(path)
 
         # Add new paths
-        # We do this in reverse order as we use `sys.path.insert(0, path)`.
-        # This ensures the end result has the correct path order.
-        pythonpath = []
-        for path, active in reversed(new_path_dict.items()):
-            if active:
-                sys.path.insert(0, path)
-                pythonpath.insert(0, path)
-        if pythonpath:
-            os.environ.update({'PYTHONPATH': os.pathsep.join(pythonpath)})
+        pypath = [path for path, active in new_path_dict.items() if active]
+        if pypath:
+            sys.path.extend(pypath)
+            os.environ.update({'PYTHONPATH': os.pathsep.join(pypath)})
         else:
             os.environ.pop('PYTHONPATH', None)
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -814,12 +814,17 @@ builtins.cell_count = cell_count
 
 
 # =============================================================================
-# Extend sys.path with paths that come from Spyder
+# PYTHONPATH and sys.path Adjustments
 # =============================================================================
+# PYTHONPATH is not passed to kernel directly, see spyder-ide/spyder#13519
+# This allows the kernel to start without crashing if modules in PYTHONPATH
+# shadow standard library modules.
 def set_spyder_pythonpath():
     pypath = os.environ.get('SPY_PYTHONPATH')
     if pypath:
         pathlist = pypath.split(os.pathsep)
-        sys.path.extend(pathlist)
+        for path in reversed(pathlist):
+            sys.path.insert(0, path)
+        os.environ.update({'PYTHONPATH': os.environ.get('SPY_PYTHONPATH')})
 
 set_spyder_pythonpath()

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -822,9 +822,7 @@ builtins.cell_count = cell_count
 def set_spyder_pythonpath():
     pypath = os.environ.get('SPY_PYTHONPATH')
     if pypath:
-        pathlist = pypath.split(os.pathsep)
-        for path in reversed(pathlist):
-            sys.path.insert(0, path)
-        os.environ.update({'PYTHONPATH': os.environ.get('SPY_PYTHONPATH')})
+        sys.path.extend(pypath.split(os.pathsep))
+        os.environ.update({'PYTHONPATH': pypath})
 
 set_spyder_pythonpath()


### PR DESCRIPTION
Update `os.environ['PYTHONPATH']` along with `sys.path`.

`PYTHONPATH` paths are inserted at position 0 instead of position 1 on `sys.path` update because the `<env>/bin` path is not included (why?), consistent with expected IPython behavior.

See spyder-ide/spyder#17512