### PR TITLE
PR: Increase minimal required version of ipykernel to 6.9.2

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,5 +1,5 @@
 cloudpickle
-ipykernel>=6.6.1
+ipykernel>=6.9.2
 ipython>=7.31.1,<8
 jupyter_client>=7.1.0
 pyzmq>=22.1.0

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,5 @@
 cloudpickle
-ipykernel>=6.6.1
+ipykernel>=6.9.2
 ipython>=7.31.1,<8
 jupyter_client>=7.1.0
 pyzmq>=22.1.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIREMENTS = [
     'backports.functools-lru-cache; python_version<"3"',
     'cloudpickle',
     'ipykernel<5; python_version<"3"',
-    'ipykernel>=6.6.1; python_version>="3"',
+    'ipykernel>=6.9.2; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.31.1,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',


### PR DESCRIPTION
This helps to fix an error when restarting the kernel after setting an interactive Matplotlib backend.