### PR TITLE
PR: Eliminate unnecessary updates of the Variable Explorer while debugging

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -311,11 +311,7 @@ class SpyderKernel(IPythonKernel):
         Publish Variable Explorer state and Pdb step through
         send_spyder_msg.
         """
-        state = dict(
-            namespace_view=self.get_namespace_view(),
-            var_properties=self.get_var_properties(),
-            step=step
-         )
+        state = dict(step=step)
         try:
             self.frontend_call(blocking=False).pdb_state(state)
         except (CommError, TimeoutError):

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -306,17 +306,6 @@ class SpyderKernel(IPythonKernel):
             return self.shell.pdb_session.do_complete(code, cursor_pos)
         return self._do_complete(code, cursor_pos)
 
-    def publish_pdb_state(self, step):
-        """
-        Publish Variable Explorer state and Pdb step through
-        send_spyder_msg.
-        """
-        state = dict(step=step)
-        try:
-            self.frontend_call(blocking=False).pdb_state(state)
-        except (CommError, TimeoutError):
-            logger.debug("Could not send Pdb state to the frontend.")
-
     def set_spyder_breakpoints(self, breakpoints):
         """
         Handle a message from the frontend

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #
 # Copyright (c) 2009- Spyder Kernels Contributors
 #
@@ -91,6 +92,9 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         super(SpyderPdb, self).__init__()
         self._pdb_breaking = False
         self._frontend_notified = False
+
+        # content of tuple: (filename, line number)
+        self._previous_step = None
 
         # Don't report hidden frames for IPython 7.24+. This attribute
         # has no effect in previous versions.
@@ -542,6 +546,12 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         return result
 
     # --- Methods overriden by us for Spyder integration
+    def postloop(self):
+        # postloop() is called when the debugger’s input prompt exists. Reset
+        # _previous_step so that publish_pdb_state() actually notifies Spyder
+        # about a changed frame the next the input prompt is entered again.
+        self._previous_step = None
+
     def preloop(self):
         """Ask Spyder for breakpoints before the first prompt is created."""
         try:
@@ -554,7 +564,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
             if self.starting:
                 self.set_spyder_breakpoints(pdb_settings['breakpoints'])
             if self.send_initial_notification:
-                self.notify_spyder()
+                self.publish_pdb_state()
         except (CommError, TimeoutError):
             logger.debug("Could not get breakpoints from the frontend.")
         super(SpyderPdb, self).preloop()
@@ -644,14 +654,11 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 
     def postcmd(self, stop, line):
         """
-        Notify spyder about a changed frame
+        Notify spyder about (possibly) changed frame
+
+        Note: The PDB commands “up”, “down” and “jump” change the current frame.
         """
-        line = line.strip()
-        if line.startswith("!"):
-            line = line[1:]
-        cmd, arg, line = self.parseline(line.strip())
-        if cmd in ("up", "down", "jump", "u", "d", "j"):
-            self.notify_spyder()
+        self.publish_pdb_state()
         return super(SpyderPdb, self).postcmd(stop, line)
 
     if PY2:
@@ -748,11 +755,16 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                     logger.debug(
                         "Could not send a Pdb continue call to the frontend.")
 
-    def notify_spyder(self):
-        """Send kernel state to the frontend."""
+    def publish_pdb_state(self):
+        """
+        Send debugger state (frame position) to the frontend.
+
+        The state is only sent if it has changed since the last update.
+        """
 
         frame = self.curframe
         if frame is None:
+            self._previous_step = None
             return
 
         # Get filename and line number of the current frame
@@ -764,12 +776,20 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
                 pass
         lineno = frame.f_lineno
 
+        if self._previous_step == (fname, lineno):
+            return
+
         # Set step of the current frame (if any)
         step = {}
+        self._previous_step = None
         if isinstance(fname, basestring) and isinstance(lineno, int):
             step = dict(fname=fname, lineno=lineno)
+            self._previous_step = (fname, lineno)
 
-        get_ipython().kernel.publish_pdb_state(step)
+        try:
+            frontend_request(blocking=False).pdb_state(dict(step=step))
+        except (CommError, TimeoutError):
+            logger.debug("Could not send Pdb state to the frontend.")
 
     def run(self, cmd, globals=None, locals=None):
         """Debug a statement executed via the exec() function.
@@ -825,6 +845,12 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         sys.settrace(self.trace_dispatch)
         self.lastcmd = debugger.lastcmd
         get_ipython().pdb_session = self
+
+        # Reset _previous_step so that publish_pdb_state() called from within
+        # postcmd() notifies Spyder about a changed debugger position. The reset
+        # is required because the recursive debugger might change the position,
+        # but the parent debugger (self) is not aware of this.
+        self._previous_step = None
 
 
 def get_new_debugger(filename, continue_if_has_breakpoints):

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -644,9 +644,14 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 
     def postcmd(self, stop, line):
         """
-        Notify spyder on any pdb command.
+        Notify spyder about a changed frame
         """
-        self.notify_spyder()
+        line = line.strip()
+        if line.startswith("!"):
+            line = line[1:]
+        cmd, arg, line = self.parseline(line.strip())
+        if cmd in ("up", "down", "jump", "u", "d", "j"):
+            self.notify_spyder()
         return super(SpyderPdb, self).postcmd(stop, line)
 
     if PY2:


### PR DESCRIPTION
See commit message for a detailed description. We have been using this patch for quite some time and haven’t experienced issues so far.

At least in theory, this should improve the performance of the debugger in Spyder (in terms of steps/second). In practical terms, performance gains are only noticeable with _very_ many variables in current scope. Think of about 80–100 variables on a rather old/slow machine, and > 200–300 variables on a rather fast one. Gains may be bigger with remote kernels, but I haven’t tested that

PS: Please let me know if I should provide instructions how to (roughly) measure the performance.