### PR TITLE
PR: Increase minimal required version of jupyter_client to 7.3.1

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.9.2
 ipython>=7.31.1,<8
-jupyter_client>=7.1.0
+jupyter_client>=7.3.1
 pyzmq>=22.1.0
 wurlitzer>=1.0.3

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,5 @@
 cloudpickle
 ipykernel>=6.9.2
 ipython>=7.31.1,<8
-jupyter_client>=7.1.0
+jupyter_client>=7.3.1
 pyzmq>=22.1.0

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ REQUIREMENTS = [
     'ipython<6; python_version<"3"',
     'ipython>=7.31.1,<8; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',
-    'jupyter-client>=7.1.0; python_version>="3"',
+    'jupyter-client>=7.3.1; python_version>="3"',
     'pyzmq>=17,<20; python_version<"3"',
     'pyzmq>=22.1.0; python_version>="3"',
     'wurlitzer>=1.0.3;platform_system!="Windows"',


### PR DESCRIPTION
That version solves several errors when Spyder is closed.

Addresses https://github.com/spyder-ide/spyder/issues/17776.