### PR TITLE
PR: Fix getting args from functions or methods

### DIFF
--- a/spyder_kernels/utils/dochelpers.py
+++ b/spyder_kernels/utils/dochelpers.py
@@ -238,7 +238,8 @@ def getargs(obj):
         func_obj = getattr(obj, '__init__')
     else:
         return []
-    if not hasattr(func_obj, 'func_code'):
+
+    if not hasattr(func_obj, '__code__'):
         # Builtin: try to extract info from doc
         args = getargsfromdoc(func_obj)
         if args is not None:
@@ -246,24 +247,29 @@ def getargs(obj):
         else:
             # Example: PyQt5
             return getargsfromdoc(obj)
-    args, _, _ = inspect.getargs(func_obj.func_code)
+
+    args, _, _ = inspect.getargs(func_obj.__code__)
     if not args:
         return getargsfromdoc(obj)
-    
+
     # Supporting tuple arguments in def statement:
     for i_arg, arg in enumerate(args):
         if isinstance(arg, list):
             args[i_arg] = "(%s)" % ", ".join(arg)
-            
+
     defaults = get_func_defaults(func_obj)
     if defaults is not None:
         for index, default in enumerate(defaults):
-            args[index+len(args)-len(defaults)] += '='+repr(default)
+            args[index + len(args) - len(defaults)] += '=' + repr(default)
+
     if inspect.isclass(obj) or inspect.ismethod(obj):
         if len(args) == 1:
             return None
-        if 'self' in args:
-            args.remove('self')
+
+    # Remove 'self' from args
+    if 'self' in args:
+        args.remove('self')
+
     return args
 
 

--- a/spyder_kernels/utils/tests/test_dochelpers.py
+++ b/spyder_kernels/utils/tests/test_dochelpers.py
@@ -9,9 +9,9 @@
 """
 Tests for dochelpers.py
 """
+
 # Standard library imports
 import os
-import sys
 
 # Test library imports
 import pytest
@@ -27,57 +27,29 @@ class Test(object):
         pass
 
 
-@pytest.mark.skipif(not PY2, reason="It fails in Python 3")
+@pytest.mark.skipif(PY2 or os.name == 'nt',
+                    reason="Only works on Linux and Mac")
 def test_dochelpers():
     """Test dochelpers."""
+    assert getargtxt(Test.method) == ['x, ', 'y=2']
     assert not getargtxt(Test.__init__)
-    if PY2:                    
-        assert getargtxt(Test.method) == ['x, ', 'y=2']
-        assert getdoc(sorted) == {'note': 'Function of __builtin__ module',
-                                  'argspec': u'(iterable, cmp=None, key=None, '
-                                              'reverse=False)',
-                                  'docstring': u'sorted(iterable, cmp=None, '
-                                                'key=None, reverse=False) --> '
-                                                'new sorted list',
-                                  'name': 'sorted'}
-        assert getargtxt(sorted) == ['iterable, ', ' cmp=None, ',
-                                     ' key=None, ', ' reverse=False']
-    else:
-        assert not getargtxt(Test.method)
-        if os.name == 'nt':
-            assert getdoc(sorted) == {'note': 'Function of builtins module',
-                                      'argspec': '(...)',
-                                      'docstring': 'Return a new list '
-                                                   'containing '
-                                                   'all items from the '
-                                                   'iterable in ascending '
-                                                   'order.\n\nA custom '
-                                                   'key function can be '
-                                                   'supplied to customise the '
-                                                   'sort order, and '
-                                                   'the\nreverse flag can be '
-                                                   'set to request the result '
-                                                   'in descending order.',
-                                      'name': 'sorted'}
-        else:
-            assert getdoc(sorted) == {'note': 'Function of builtins module',
-                                      'argspec': '(...)',
-                                      'docstring': 'Return a new list '
-                                                   'containing '
-                                                   'all items from the '
-                                                   'iterable in ascending '
-                                                   'order.\n\nA custom '
-                                                   'key function can be '
-                                                   'supplied to customize the '
-                                                   'sort order, and '
-                                                   'the\nreverse flag can be '
-                                                   'set to request the result '
-                                                   'in descending order.',
-                                      'name': 'sorted'}
-        assert not getargtxt(sorted)
+
+    assert getdoc(sorted) == {
+        'note': 'Function of builtins module',
+        'argspec': '(...)',
+        'docstring': 'Return a new list containing all items from the '
+                     'iterable in ascending order.\n\nA custom key function '
+                     'can be supplied to customize the sort order, and the\n'
+                     'reverse flag can be set to request the result in '
+                     'descending order.',
+        'name': 'sorted'
+    }
+    assert not getargtxt(sorted)
+
     assert isdefined('numpy.take', force_import=True)
     assert isdefined('__import__')
-    assert not isdefined('.keys', force_import=True)
+    assert not isdefined('zzz', force_import=True)
+
     assert getobj('globals') == 'globals'
     assert not getobj('globals().keys')
     assert getobj('+scipy.signal.') == 'scipy.signal'


### PR DESCRIPTION
This was failing because we were using old Python 2 attributes for callables.