### PR TITLE
PR: Fix debug filename path for remote debugging

### DIFF
--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -31,7 +31,7 @@ from spyder_kernels.customize.spyderpdb import SpyderPdb, get_new_debugger
 from spyder_kernels.customize.umr import UserModuleReloader
 from spyder_kernels.py3compat import (
     PY2, _print, encode, compat_exec, FileNotFoundError)
-from spyder_kernels.customize.utils import capture_last_Expr
+from spyder_kernels.customize.utils import capture_last_Expr, canonic
 
 if not PY2:
     from IPython.core.inputtransformer2 import (
@@ -535,20 +535,6 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
     return _exec_file(
         filename, args, wdir, namespace,
         post_mortem, current_namespace, stack_depth=1)
-
-
-def canonic(filename):
-    """
-    Return canonical form of filename.
-
-    This is a copy of bdb.canonic, so that the debugger will process 
-    filenames in the same way
-    """
-    if filename == "<" + filename[1:-1] + ">":
-        return filename
-    canonic = os.path.abspath(filename)
-    canonic = os.path.normcase(canonic)
-    return canonic
 
 
 def _exec_file(filename=None, args=None, wdir=None, namespace=None,

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -504,7 +504,7 @@ def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False,
 
 
 def get_file_code(filename, save_all=True, raise_exception=False):
-    """Retrive the content of a file."""
+    """Retrieve the content of a file."""
     # Get code from spyder
     try:
         return frontend_request(blocking=True).get_file_code(

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -32,8 +32,7 @@ from spyder_kernels.customize.spyderpdb import SpyderPdb, get_new_debugger
 from spyder_kernels.customize.umr import UserModuleReloader
 from spyder_kernels.py3compat import (
     TimeoutError, PY2, _print, encode, compat_exec, FileNotFoundError)
-from spyder_kernels.customize.utils import (
-    capture_last_Expr, normalise_filename)
+from spyder_kernels.customize.utils import capture_last_Expr
 
 if not PY2:
     from IPython.core.inputtransformer2 import (
@@ -658,7 +657,7 @@ def debugfile(filename=None, args=None, wdir=None, post_mortem=False,
     if shell.is_debugging():
         # Recursive
         code = (
-            "runfile({}".format(repr(normalise_filename(filename))) +
+            "runfile({}".format(repr(filename)) +
             ", args=%r, wdir=%r, current_namespace=%r)" % (
                 args, wdir, current_namespace)
         )
@@ -771,7 +770,7 @@ def debugcell(cellname, filename=None, post_mortem=False):
         # Recursive
         code = (
             "runcell({}, ".format(repr(cellname)) +
-            "{})".format(repr(normalise_filename(filename)))
+            "{})".format(repr(filename))
         )
         shell.pdb_session.enter_recursive_debugger(
             code, filename, False,

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -505,11 +505,12 @@ def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False,
         __tracebackhide__ = "__pdb_exit__"
 
 
-def get_file_code(filename, raise_exception=False):
+def get_file_code(filename, save_all=True, raise_exception=False):
     """Retrive the content of a file."""
     # Get code from spyder
     try:
-        return frontend_request(blocking=True).get_file_code(filename)
+        return frontend_request(blocking=True).get_file_code(
+            filename, save_all=save_all)
     except Exception:
         # Maybe this is a local file
         try:
@@ -742,7 +743,7 @@ def _exec_cell(cellname, filename=None, post_mortem=False, stack_depth=0,
     # See Spyder PR #7310.
     ipython_shell.events.trigger('post_execute')
     if file_code is None:
-        file_code = get_file_code(filename)
+        file_code = get_file_code(filename, save_all=False)
 
     # Normalise the filename
     filename = os.path.abspath(filename)
@@ -785,7 +786,7 @@ def debugcell(cellname, filename=None, post_mortem=False):
             filename=debugger.canonic(filename),
             exec_fun=debugger.run,
             stack_depth=1,
-            file_code=get_file_code(filename)
+            file_code=get_file_code(filename, save_all=False)
         )
 
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -537,6 +537,20 @@ def runfile(filename=None, args=None, wdir=None, namespace=None,
         post_mortem, current_namespace, stack_depth=1)
 
 
+def canonic(filename):
+    """
+    Return canonical form of filename.
+
+    This is a copy of bdb.canonic, so that the debugger will process 
+    filenames in the same way
+    """
+    if filename == "<" + filename[1:-1] + ">":
+        return filename
+    canonic = os.path.abspath(filename)
+    canonic = os.path.normcase(canonic)
+    return canonic
+
+
 def _exec_file(filename=None, args=None, wdir=None, namespace=None,
                post_mortem=False, current_namespace=False, stack_depth=0,
                exec_fun=None, canonic_filename=None):
@@ -576,9 +590,7 @@ def _exec_file(filename=None, args=None, wdir=None, namespace=None,
     if canonic_filename is not None:
         filename = canonic_filename
     else:
-        # Normalise the filename
-        filename = os.path.abspath(filename)
-        filename = os.path.normcase(filename)
+        filename = canonic(filename)
 
     with NamespaceManager(filename, namespace, current_namespace,
                           file_code=file_code, stack_depth=stack_depth + 1
@@ -741,8 +753,7 @@ def _exec_cell(cellname, filename=None, post_mortem=False, stack_depth=0,
         filename = canonic_filename
     else:
         # Normalise the filename
-        filename = os.path.abspath(filename)
-        filename = os.path.normcase(filename)
+        filename = canonic(filename)
 
     with NamespaceManager(filename, current_namespace=True,
                           file_code=file_code, stack_depth=stack_depth + 1

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -23,7 +23,6 @@ import sys
 import time
 import warnings
 
-from IPython import __version__ as ipy_version
 from IPython.core.getipython import get_ipython
 
 from spyder_kernels.comms.frontendcomm import frontend_request
@@ -31,7 +30,7 @@ from spyder_kernels.customize.namespace_manager import NamespaceManager
 from spyder_kernels.customize.spyderpdb import SpyderPdb, get_new_debugger
 from spyder_kernels.customize.umr import UserModuleReloader
 from spyder_kernels.py3compat import (
-    TimeoutError, PY2, _print, encode, compat_exec, FileNotFoundError)
+    PY2, _print, encode, compat_exec, FileNotFoundError)
 from spyder_kernels.customize.utils import capture_last_Expr
 
 if not PY2:

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -839,7 +839,6 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 
         debugger.set_remote_filename(filename)
         debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
-        debugger._user_requested_quit = False
 
         # Enter recursive debugger
         sys.call_tracing(debugger.run, (code, globals, locals))
@@ -866,5 +865,4 @@ def get_new_debugger(filename, continue_if_has_breakpoints):
     debugger = SpyderPdb()
     debugger.set_remote_filename(filename)
     debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
-    debugger._user_requested_quit = False
     return debugger

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -10,7 +10,6 @@
 import ast
 import bdb
 import logging
-import os
 import sys
 import traceback
 from collections import namedtuple

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -89,10 +89,8 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         self.pdb_stop_first_line = True
         self._disable_next_stack_entry = False
         super(SpyderPdb, self).__init__()
-        self._user_requested_quit = False
         self._pdb_breaking = False
         self._frontend_notified = False
-        self._wait_for_mainpyfile = True
 
         # content of tuple: (filename, line number)
         self._previous_step = None
@@ -839,9 +837,9 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         debugger.use_rawinput = self.use_rawinput
         debugger.prompt = "(%s) " % self.prompt.strip()
 
-        debugger.remote_filename = filename
-        debugger.mainpyfile = debugger.canonic(filename)
+        debugger.set_remote_filename(filename)
         debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
+        debugger._user_requested_quit = False
 
         # Enter recursive debugger
         sys.call_tracing(debugger.run, (code, globals, locals))
@@ -856,11 +854,17 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         # but the parent debugger (self) is not aware of this.
         self._previous_step = None
 
+    def set_remote_filename(self, filename):
+        """set remote filename to signal spyder on mainpyfile."""
+        self.remote_filename = filename
+        self.mainpyfile = self.canonic(filename)
+        self._wait_for_mainpyfile = True
+
 
 def get_new_debugger(filename, continue_if_has_breakpoints):
     """Get a new debugger."""
     debugger = SpyderPdb()
-    debugger.remote_filename = filename
-    debugger.mainpyfile = debugger.canonic(filename)
+    debugger.set_remote_filename(filename)
     debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
+    debugger._user_requested_quit = False
     return debugger

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -89,6 +89,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         self.pdb_stop_first_line = True
         self._disable_next_stack_entry = False
         super(SpyderPdb, self).__init__()
+        self._user_requested_quit = False
         self._pdb_breaking = False
         self._frontend_notified = False
         self._wait_for_mainpyfile = True
@@ -841,7 +842,6 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         debugger.remote_filename = filename
         debugger.mainpyfile = debugger.canonic(filename)
         debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
-        debugger._user_requested_quit = False
 
         # Enter recursive debugger
         sys.call_tracing(debugger.run, (code, globals, locals))
@@ -860,9 +860,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
 def get_new_debugger(filename, continue_if_has_breakpoints):
     """Get a new debugger."""
     debugger = SpyderPdb()
-
     debugger.remote_filename = filename
     debugger.mainpyfile = debugger.canonic(filename)
     debugger.continue_if_has_breakpoints = continue_if_has_breakpoints
-    debugger._user_requested_quit = False
     return debugger

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -855,7 +855,7 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         self._previous_step = None
 
     def set_remote_filename(self, filename):
-        """set remote filename to signal spyder on mainpyfile."""
+        """Set remote filename to signal Spyder on mainpyfile."""
         self.remote_filename = filename
         self.mainpyfile = self.canonic(filename)
         self._wait_for_mainpyfile = True

--- a/spyder_kernels/customize/utils.py
+++ b/spyder_kernels/customize/utils.py
@@ -115,3 +115,17 @@ def capture_last_Expr(code_ast, out_varname):
         assign_node.col_offset = expr_node.col_offset
         code_ast.body[-1] = assign_node
     return code_ast, capture_last_expression
+
+
+def canonic(filename):
+    """
+    Return canonical form of filename.
+
+    This is a copy of bdb.canonic, so that the debugger will process 
+    filenames in the same way
+    """
+    if filename == "<" + filename[1:-1] + ">":
+        return filename
+    canonic = os.path.abspath(filename)
+    canonic = os.path.normcase(canonic)
+    return canonic

--- a/spyder_kernels/customize/utils.py
+++ b/spyder_kernels/customize/utils.py
@@ -115,11 +115,3 @@ def capture_last_Expr(code_ast, out_varname):
         assign_node.col_offset = expr_node.col_offset
         code_ast.body[-1] = assign_node
     return code_ast, capture_last_expression
-
-
-def normalise_filename(filename):
-    """Normalise path for window."""
-    # Recursive
-    if os.name == 'nt':
-        return filename.replace('\\', '/')
-    return filename


### PR DESCRIPTION
On linux when processing window paths:
```
IPdb [5]: os.path.abspath("C:/Users")
Out  [5]: '/home/debian/spyder-kernels/C:/Users'
```
This PR changes the filename handling to fix https://github.com/spyder-ide/spyder/issues/18330