### PR TITLE
PR: Add wrappers to register methods of spyder-kernels by external plugins

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -98,6 +98,20 @@ class SpyderKernel(IPythonKernel):
         self._running_namespace = None
         self.faulthandler_handle = None
 
+    def register_frontend_fun(self, fun):
+        """
+        Register frontend function
+        """
+        self.frontend_comm.register_call_handler(
+            fun.__name__, fun)
+        return fun
+
+    def unregister_frontend_fun(self, fun_name):
+        """
+        Unregister frontend function
+        """
+        self.frontend_comm.register_call_handler(fun_name, None)
+
     # -- Public API -----------------------------------------------------------
     def do_shutdown(self, restart):
         """Disable faulthandler if enabled before proceeding."""


### PR DESCRIPTION
The idea is to let external plugins expand spyder-kernels by sending source code to a kernel.
 - A setup source code could be used to modify the kernel as needed
 - A list of comm handlers can be registered

Spyder extensions would call `register_external_plugin` in `ShellConnectMainWidget.create_new_widget` and `unregister_external_plugin` in `ShellConnectMainWidget.close_widget`

The imports would be placed in setup_code

`get_ipython()` is imported automatically as a convenience

you can use inspect.getsource  to get the source of functions if you don’t want to have strings of code in the source code