### PR TITLE
PR: Add handlers to interrupt executions and enter the debugger after that

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -226,7 +226,9 @@ class WriteWrapper(object):
 
                 # Don't print handler name for `show_mpl_backend_errors`
                 # because we have a specific message for it.
-                if repr(self._name) != "'show_mpl_backend_errors'":
+                # request_pdb_stop is expected to print messages.
+                if self._name not in [
+                        'show_mpl_backend_errors', 'request_pdb_stop']:
                     self._write(
                         "\nOutput from spyder call " + repr(self._name) + ":\n"
                     )

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -86,6 +86,8 @@ class SpyderKernel(IPythonKernel):
             'enable_faulthandler': self.enable_faulthandler,
             "flush_std": self.flush_std,
             'get_current_frames': self.get_current_frames,
+            'request_pdb_stop': self.shell.request_pdb_stop,
+            'raise_interrupt_signal': self.shell.raise_interrupt_signal,
             }
         for call_id in handlers:
             self.frontend_comm.register_call_handler(
@@ -935,3 +937,12 @@ class SpyderKernel(IPythonKernel):
         except Exception:
             self.comm_manager.log.error(
                 'Exception in comm_msg for %s', comm_id, exc_info=True)
+
+    def pre_handler_hook(self):
+        """Hook to execute before calling message handler"""
+        pass
+
+    def post_handler_hook(self):
+        """Hook to execute after calling message handler"""
+        # keep ipykernel behavior of resetting sigint every call
+        self.shell.register_debugger_sigint()

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -946,3 +946,6 @@ class SpyderKernel(IPythonKernel):
         """Hook to execute after calling message handler"""
         # keep ipykernel behavior of resetting sigint every call
         self.shell.register_debugger_sigint()
+        # Install a global tracing function so that pdb.set_trace can work
+        # This is a low overhead function that disables itself immediately
+        sys.settrace(lambda frame, event, arg: None)

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -948,4 +948,5 @@ class SpyderKernel(IPythonKernel):
         self.shell.register_debugger_sigint()
         # Install a global tracing function so that pdb.set_trace can work
         # This is a low overhead function that disables itself immediately
+        # See https://docs.python.org/3/library/sys.html#sys.settrace
         sys.settrace(lambda frame, event, arg: None)

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -946,7 +946,5 @@ class SpyderKernel(IPythonKernel):
         """Hook to execute after calling message handler"""
         # keep ipykernel behavior of resetting sigint every call
         self.shell.register_debugger_sigint()
-        # Install a global tracing function so that pdb.set_trace can work
-        # This is a low overhead function that disables itself immediately
-        # See https://docs.python.org/3/library/sys.html#sys.settrace
-        sys.settrace(lambda frame, event, arg: None)
+        # Reset tracing function so that pdb.set_trace works
+        sys.settrace(None)

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -99,7 +99,8 @@ class SpyderShell(ZMQInteractiveShell):
             return
         self._pdb_obj_stack.append(pdb_obj)
         try:
-            self.kernel.frontend_call(blocking=True).set_debug_state(True)
+            self.kernel.frontend_call(blocking=True).set_debug_state(
+                len(self._pdb_obj_stack))
         except (CommError, TimeoutError):
             logger.debug("Could not send debugging state to the frontend.")
 
@@ -110,7 +111,8 @@ class SpyderShell(ZMQInteractiveShell):
             return
         self._pdb_obj_stack.pop()
         try:
-            self.kernel.frontend_call(blocking=True).set_debug_state(False)
+            self.kernel.frontend_call(blocking=True).set_debug_state(
+                len(self._pdb_obj_stack))
         except (CommError, TimeoutError):
             logger.debug("Could not send debugging state to the frontend.")
 

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -105,7 +105,7 @@ class SpyderShell(ZMQInteractiveShell):
             logger.debug("Could not send debugging state to the frontend.")
 
     def remove_pdb_session(self, pdb_obj):
-        """Add a pdb object to the stack."""
+        """Remove a pdb object to the stack."""
         if self.pdb_session != pdb_obj:
             # Already removed
             return
@@ -172,8 +172,8 @@ class SpyderShell(ZMQInteractiveShell):
     def raise_interrupt_signal(self):
         """Raise interrupt signal."""
         if os.name == "nt":
-            # check if signal handler is callable
-            # to avoid 'int not callable' error (Python issue #23395)
+            # Check if signal handler is callable to avoid
+            # 'int not callable' error (Python issue #23395)
             if callable(signal.getsignal(signal.SIGINT)):
                 interrupt_main()
             else:
@@ -183,7 +183,7 @@ class SpyderShell(ZMQInteractiveShell):
             self.kernel._send_interupt_children()
 
     def request_pdb_stop(self):
-        """Request pdb to stop at next possible position."""
+        """Request pdb to stop at the next possible position."""
         pdb_session = self.pdb_session
         if pdb_session:
             if pdb_session.interrupting:
@@ -191,22 +191,21 @@ class SpyderShell(ZMQInteractiveShell):
                 return
             # trace_dispatch is active, stop at the next possible position
             pdb_session.interrupt()
-
         elif (self.spyderkernel_sigint_handler
               == signal.getsignal(signal.SIGINT)):
             # Use spyderkernel_sigint_handler
             self._request_pdb_stop = True
             self.raise_interrupt_signal()
-
         else:
             logger.debug(
-                "Can not signal main thread to stop as SIGINT"
-                " handler was replaced and the debugger is not active. "
+                "Can not signal main thread to stop as SIGINT "
+                "handler was replaced and the debugger is not active. "
                 "The current handler is: " +
-                repr(signal.getsignal(signal.SIGINT)))
+                repr(signal.getsignal(signal.SIGINT))
+            )
 
     def spyderkernel_sigint_handler(self, signum, frame):
-        """Enter a debugger."""
+        """SIGINT handler."""
         pdb_session = self.pdb_session
         if self._request_pdb_stop:
             # SIGINT called from request_pdb_stop

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -105,7 +105,7 @@ class SpyderShell(ZMQInteractiveShell):
             logger.debug("Could not send debugging state to the frontend.")
 
     def remove_pdb_session(self, pdb_obj):
-        """Remove a pdb object to the stack."""
+        """Remove a pdb object from the stack."""
         if self.pdb_session != pdb_obj:
             # Already removed
             return

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -95,7 +95,7 @@ class SpyderShell(ZMQInteractiveShell):
     def add_pdb_session(self, pdb_obj):
         """Add a pdb object to the stack."""
         if self.pdb_session == pdb_obj:
-            # Already Added
+            # Already added
             return
         self._pdb_obj_stack.append(pdb_obj)
         try:

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1335,6 +1335,8 @@ def test_enter_debug():
                     # pdb entered
                     break
                 comm.handle_msg(msg)
+            if msg.get('msg_type') == 'stream':
+                print(msg["content"].get("text"))
 
         assert time.time() - t0 < 5
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1241,7 +1241,7 @@ def test_global_message(tmpdir):
 
 def test_interrupt():
     """
-    Test that using `global` triggers a warning.
+    Test that the kernel can be interrupted by calling a comm handler.
     """
     # Command to start the kernel
     cmd = "from spyder_kernels.console import start; start.main()"
@@ -1294,9 +1294,10 @@ def test_interrupt():
         assert time.time() - t0 < 5
 
 
-def test_enter_debug():
+def test_enter_debug_after_interruption():
     """
-    Test that using `global` triggers a warning.
+    Test that we can enter the debugger after interrupting the current
+    execution.
     """
     # Command to start the kernel
     cmd = "from spyder_kernels.console import start; start.main()"
@@ -1316,7 +1317,7 @@ def test_enter_debug():
         t0 = time.time()
         msg_id = client.execute("for i in range(100): time.sleep(.1)")
         time.sleep(.2)
-        # Raise interrupt on control_channel
+        # Request to enter the debugger
         kernel_comm.remote_call().request_pdb_stop()
         # Wait for debug message
         while True:

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -118,7 +118,7 @@ class Comm():
         """
         self.target_name = target_name
         self.kernel_client = kernel_client
-        self.comm_id =  uuid.uuid1().hex
+        self.comm_id = uuid.uuid1().hex
         self._msg_callback = msg_callback
         self._close_callback = close_callback
         self._send_channel = self.kernel_client.shell_channel
@@ -1328,7 +1328,8 @@ def test_enter_debug():
                 # not from my request
                 continue
             if msg.get('msg_type') == 'comm_msg':
-                if msg["content"].get("data", {}).get("content", {}).get('call_name') =='get_pdb_settings':
+                if msg["content"].get("data", {}).get("content", {}).get(
+                        'call_name') == 'get_pdb_settings':
                     # pdb entered
                     break
                 comm.handle_msg(msg)

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -819,7 +819,7 @@ def test_do_complete(kernel):
     pdb_obj.curframe = inspect.currentframe()
     pdb_obj.prompt_waiting = True
     pdb_obj.completenames = lambda *ignore: ['baba']
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
     match = kernel.do_complete('ba', 2)
     assert 'baba' in match['matches']
     pdb_obj.curframe = None
@@ -878,7 +878,7 @@ def test_comprehensions_with_locals_in_pdb(kernel):
     pdb_obj.curframe = inspect.currentframe()
     pdb_obj.prompt_waiting = True
     pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
 
     # Create a local variable.
     kernel.shell.pdb_session.default('zz = 10')
@@ -905,7 +905,7 @@ def test_comprehensions_with_locals_in_pdb_2(kernel):
     pdb_obj.curframe = inspect.currentframe()
     pdb_obj.prompt_waiting = True
     pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
 
     # Create a local variable.
     kernel.shell.pdb_session.default('aa = [1, 2]')
@@ -932,7 +932,7 @@ def test_namespaces_in_pdb(kernel):
     pdb_obj.curframe = inspect.currentframe()
     pdb_obj.prompt_waiting = True
     pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
 
     # Check adding something to globals works
     pdb_obj.default("globals()['test2'] = 0")
@@ -975,7 +975,7 @@ def test_functions_with_locals_in_pdb(kernel):
     Frame = namedtuple("Frame", ["f_globals"])
     pdb_obj.curframe = Frame(f_globals=kernel.shell.user_ns)
     pdb_obj.curframe_locals = kernel.shell.user_ns
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
 
     # Create a local function.
     kernel.shell.pdb_session.default(
@@ -1008,7 +1008,7 @@ def test_functions_with_locals_in_pdb_2(kernel):
     pdb_obj.curframe = inspect.currentframe()
     pdb_obj.prompt_waiting = True
     pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
 
     # Create a local function.
     kernel.shell.pdb_session.default(
@@ -1046,7 +1046,7 @@ def test_locals_globals_in_pdb(kernel):
     pdb_obj.curframe = inspect.currentframe()
     pdb_obj.prompt_waiting = True
     pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
-    kernel.shell.pdb_session = pdb_obj
+    kernel.shell._pdb_obj_stack = [pdb_obj]
 
     assert kernel.get_value('a') == 1
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1266,6 +1266,7 @@ def test_interrupt():
         t0 = time.time()
         msg_id = client.execute("for i in range(100): time.sleep(.1)")
         time.sleep(.2)
+        # Raise interrupt on control_channel
         kernel_comm.remote_call().raise_interrupt_signal()
         # Wait for shell message
         while True:
@@ -1277,10 +1278,15 @@ def test_interrupt():
             break
         assert time.time() - t0 < 5
 
+        if os.name == 'nt':
+            # Windows doesn't do "interrupting sleep"
+            return
+
         # Try interrupting sleep
         t0 = time.time()
         msg_id = client.execute("time.sleep(10)")
         time.sleep(.2)
+        # Raise interrupt on control_channel
         kernel_comm.remote_call().raise_interrupt_signal()
         # Wait for shell message
         while True:

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1327,6 +1327,8 @@ def test_enter_debug():
         while True:
             assert time.time() - t0 < 5
             msg = client.get_iopub_msg(timeout=TIMEOUT)
+            if msg.get('msg_type') == 'stream':
+                print(msg["content"].get("text"))
             if msg["parent_header"].get("msg_id") != msg_id:
                 # not from my request
                 continue
@@ -1335,8 +1337,6 @@ def test_enter_debug():
                     # pdb entered
                     break
                 comm.handle_msg(msg)
-            if msg.get('msg_type') == 'stream':
-                print(msg["content"].get("text"))
 
         assert time.time() - t0 < 5
 

--- a/spyder_kernels/customize/namespace_manager.py
+++ b/spyder_kernels/customize/namespace_manager.py
@@ -26,7 +26,7 @@ def new_main_mod(filename, modname):
     main_mod.__file__ = filename
     # It seems pydoc (and perhaps others) needs any module instance to
     # implement a __nonzero__ method
-    main_mod.__nonzero__ = lambda : True
+    main_mod.__nonzero__ = lambda: True
 
     return main_mod
 

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -426,7 +426,7 @@ def exec_code(code, filename, ns_globals, ns_locals=None, post_mortem=False,
         if (isinstance(error, bdb.BdbQuit)
                 and ipython_shell.pdb_session):
             # Ignore BdbQuit if we are debugging, as it is expected.
-            ipython_shell.pdb_session = None
+            pass
         elif post_mortem and isinstance(error, Exception):
             error_type, error, tb = sys.exc_info()
             post_mortem_excepthook(error_type, error, tb)

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -11,6 +11,7 @@ import ast
 import bdb
 import builtins
 import logging
+import os
 import sys
 import traceback
 import threading
@@ -21,6 +22,7 @@ from IPython.core.debugger import Pdb as ipyPdb
 from IPython.core.getipython import get_ipython
 from IPython.core.inputtransformer2 import TransformerManager
 
+import spyder_kernels
 from spyder_kernels.comms.frontendcomm import CommError, frontend_request
 from spyder_kernels.customize.utils import path_is_library, capture_last_Expr
 
@@ -331,6 +333,9 @@ class SpyderPdb(ipyPdb):
             # This is not a file
             return True
         if self.pdb_ignore_lib and path_is_library(filename):
+            return False
+        if os.path.dirname(spyder_kernels.__file__) in filename:
+            # This is spyder-kernels internals
             return False
         return True
 

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -96,6 +96,7 @@ class SpyderPdb(ipyPdb):
         self.remote_filename = None
 
         # State of the prompt
+        # Needed to know which namespace to show (user or current frame)
         self.prompt_waiting = False
 
         # Line received from the frontend

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -102,7 +102,7 @@ class SpyderPdb(ipyPdb):
         # Line received from the frontend
         self._cmd_input_line = None
 
-        # Disable sigint so we can do it ourself
+        # Disable sigint so we can do it ourselves
         self.nosigint = True
 
         # Keep track of interrupting state to avoid several interruptions


### PR DESCRIPTION
This PR adds two functions to the comms:
 - `request_pdb_stop` that enters the debugger immediately (at the next python interaction). If the kernel is not debugging, it creates a debugger.
 - `raise_interrupt_signal` that raises an interrupt signal on request. This allows interrupting remote kernels.

The `shell.pdb_session` handling is improved as before it would not be unregistered in some cases. Now it returns the tracing pdb session. It handles recursive debugger by keeping a stack of debuggers.

A new function handles interrupt signals: `shell.spyderkernel_sigint_handler`. It is reset at every prompt to keep the behaviour constant from ipykernel which resets the SIGINT handler at every message (in `post_handler_hook`). It will play nice with a currently debugging shell. This completely replaces `Pdb.sigint_handler` that is disabled.

Any frame in spyder-kernels is hidden to avoid problems when interrupting.








