### PR TITLE
PR: Wait for connection file to be written

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -84,7 +84,16 @@ def setup_kernel(cmd):
             raise IOError("Connection file %r never arrived" % connection_file)
 
         client = BlockingKernelClient(connection_file=connection_file)
-        client.load_connection_file()
+        tic = time.time()
+        while True:
+            try:
+                client.load_connection_file()
+                break
+            except ValueError:
+                # The file is not written yet
+                if time.time() > tic + SETUP_TIMEOUT:
+                    # Give up after 5s
+                    raise IOError("Kernel failed to write connection file")
         client.start_channels()
         client.wait_for_ready()
         try:


### PR DESCRIPTION
Sometimes, the connection file is not yet written when the client tries to load it. This remove test flakyness.