### PR TITLE
PR: Use `get_size` to get variable length for `get_var_properties` to prevent triggering Dask tasks

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -29,7 +29,8 @@ from spyder_kernels.comms.frontendcomm import FrontendComm
 from spyder_kernels.utils.iofuncs import iofunctions
 from spyder_kernels.utils.mpl import (
     MPL_BACKENDS_FROM_SPYDER, MPL_BACKENDS_TO_SPYDER, INLINE_FIGURE_FORMATS)
-from spyder_kernels.utils.nsview import get_remote_data, make_remote_view
+from spyder_kernels.utils.nsview import (
+    get_remote_data, make_remote_view, get_size)
 from spyder_kernels.console.shell import SpyderShell
 
 if PY3:
@@ -631,7 +632,7 @@ class SpyderKernel(IPythonKernel):
     def _get_len(self, var):
         """Return sequence length"""
         try:
-            return len(var)
+            return get_size(var)
         except:
             return None
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -219,7 +219,7 @@ def test_get_var_properties(kernel):
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
     assert "'is_dict': False" in var_properties
-    assert "'len': None" in var_properties
+    assert "'len': 1" in var_properties
     assert "'is_array': False" in var_properties
     assert "'is_image': False" in var_properties
     assert "'is_data_frame': False" in var_properties
@@ -269,7 +269,7 @@ def test_remove_value(kernel):
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
     assert "'is_dict': False" in var_properties
-    assert "'len': None" in var_properties
+    assert "'len': 1" in var_properties
     assert "'is_array': False" in var_properties
     assert "'is_image': False" in var_properties
     assert "'is_data_frame': False" in var_properties
@@ -294,7 +294,7 @@ def test_copy_value(kernel):
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
     assert "'is_dict': False" in var_properties
-    assert "'len': None" in var_properties
+    assert "'len': 1" in var_properties
     assert "'is_array': False" in var_properties
     assert "'is_image': False" in var_properties
     assert "'is_data_frame': False" in var_properties
@@ -307,7 +307,7 @@ def test_copy_value(kernel):
     assert "'b'" in var_properties
     assert "'is_list': False" in var_properties
     assert "'is_dict': False" in var_properties
-    assert "'len': None" in var_properties
+    assert "'len': 1" in var_properties
     assert "'is_array': False" in var_properties
     assert "'is_image': False" in var_properties
     assert "'is_data_frame': False" in var_properties
@@ -344,7 +344,7 @@ def test_load_data(kernel):
     assert "'a'" in var_properties
     assert "'is_list': False" in var_properties
     assert "'is_dict': False" in var_properties
-    assert "'len': None" in var_properties
+    assert "'len': 1" in var_properties
     assert "'is_array': False" in var_properties
     assert "'is_image': False" in var_properties
     assert "'is_data_frame': False" in var_properties


### PR DESCRIPTION
Addresses spyder-ide/spyder#18434