### PR TITLE
PR: Only access sys.stdout and sys.stderr once

### DIFF
--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -259,22 +259,22 @@ class FrontendComm(CommBase):
 
     def _remote_callback(self, call_name, call_args, call_kwargs):
         """Call the callback function for the remote call."""
-        # save stdout and stderr in case another thread changes them
-        current_stdout = sys.stdout
-        current_stderr = sys.stderr
-        saved_stdout_write = current_stdout.write
-        saved_stderr_write = current_stderr.write
-        thread_id = threading.get_ident()
-        current_stdout.write = WriteWrapper(
-            saved_stdout_write, call_name, thread_id)
-        current_stderr.write = WriteWrapper(
-            saved_stderr_write, call_name, thread_id)
-        try:
-            return super(FrontendComm, self)._remote_callback(
-                call_name, call_args, call_kwargs)
-        finally:
-            current_stdout.write = saved_stdout_write
-            current_stderr.write = saved_stderr_write
+        with self.comm_lock:
+            current_stdout = sys.stdout
+            current_stderr = sys.stderr
+            saved_stdout_write = current_stdout.write
+            saved_stderr_write = current_stderr.write
+            thread_id = threading.get_ident()
+            current_stdout.write = WriteWrapper(
+                saved_stdout_write, call_name, thread_id)
+            current_stderr.write = WriteWrapper(
+                saved_stderr_write, call_name, thread_id)
+            try:
+                return super(FrontendComm, self)._remote_callback(
+                    call_name, call_args, call_kwargs)
+            finally:
+                current_stdout.write = saved_stdout_write
+                current_stderr.write = saved_stderr_write
 
 
 class WriteWrapper(object):

--- a/spyder_kernels/comms/frontendcomm.py
+++ b/spyder_kernels/comms/frontendcomm.py
@@ -259,19 +259,22 @@ class FrontendComm(CommBase):
 
     def _remote_callback(self, call_name, call_args, call_kwargs):
         """Call the callback function for the remote call."""
-        saved_stdout_write = sys.stdout.write
-        saved_stderr_write = sys.stderr.write
+        # save stdout and stderr in case another thread changes them
+        current_stdout = sys.stdout
+        current_stderr = sys.stderr
+        saved_stdout_write = current_stdout.write
+        saved_stderr_write = current_stderr.write
         thread_id = threading.get_ident()
-        sys.stdout.write = WriteWrapper(
+        current_stdout.write = WriteWrapper(
             saved_stdout_write, call_name, thread_id)
-        sys.stderr.write = WriteWrapper(
+        current_stderr.write = WriteWrapper(
             saved_stderr_write, call_name, thread_id)
         try:
             return super(FrontendComm, self)._remote_callback(
                 call_name, call_args, call_kwargs)
         finally:
-            sys.stdout.write = saved_stdout_write
-            sys.stderr.write = saved_stderr_write
+            current_stdout.write = saved_stdout_write
+            current_stderr.write = saved_stderr_write
 
 
 class WriteWrapper(object):


### PR DESCRIPTION
Avoid accessing `sys.stdout` and `sys.stderr` multiple times in case another threads modifies it.
Might help with https://github.com/spyder-ide/spyder/issues/19735