### PR TITLE
PR: Patch for CVE-2007-4559 Tar directory traversal

### DIFF
--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -23,7 +23,6 @@ import tarfile
 import tempfile
 import shutil
 import types
-import warnings
 import json
 import inspect
 import dis
@@ -370,6 +369,27 @@ def save_dictionary(data, filename):
     return error_message
 
 
+def is_within_directory(directory, target):
+    """Check if a file is within a directory."""
+    abs_directory = os.path.abspath(directory)
+    abs_target = os.path.abspath(target)
+    prefix = os.path.commonprefix([abs_directory, abs_target])
+    return prefix == abs_directory
+
+
+def safe_extract(tar, path=".", members=None, numeric_owner=False):
+    """Safely extract a tar file."""
+    for member in tar.getmembers():
+        member_path = os.path.join(path, member.name)
+        if not is_within_directory(path, member_path):
+            raise Exception(
+                "Attempted path traversal in tar file {}".format(
+                    repr(tar.name)
+                )
+            )
+    tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
 def load_dictionary(filename):
     """Load dictionary from .spydata file"""
     filename = osp.abspath(filename)
@@ -380,26 +400,11 @@ def load_dictionary(filename):
     error_message = None
     try:
         with tarfile.open(filename, "r") as tar:
-            def is_within_directory(directory, target):
-                
-                abs_directory = os.path.abspath(directory)
-                abs_target = os.path.abspath(target)
-            
-                prefix = os.path.commonprefix([abs_directory, abs_target])
-                
-                return prefix == abs_directory
-            
-            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-            
-                for member in tar.getmembers():
-                    member_path = os.path.join(path, member.name)
-                    if not is_within_directory(path, member_path):
-                        raise Exception("Attempted Path Traversal in Tar File")
-            
-                tar.extractall(path, members, numeric_owner=numeric_owner) 
-                
-            
-            safe_extract(tar)
+            if PY2:
+                tar.extractall()
+            else:
+                safe_extract(tar)
+
         pickle_filename = glob.glob('*.pickle')[0]
         # 'New' format (Spyder >=2.2 for Python 2 and Python 3)
         with open(pickle_filename, 'rb') as fdesc:

--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -380,7 +380,26 @@ def load_dictionary(filename):
     error_message = None
     try:
         with tarfile.open(filename, "r") as tar:
-            tar.extractall()
+            def is_within_directory(directory, target):
+                
+                abs_directory = os.path.abspath(directory)
+                abs_target = os.path.abspath(target)
+            
+                prefix = os.path.commonprefix([abs_directory, abs_target])
+                
+                return prefix == abs_directory
+            
+            def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
+            
+                for member in tar.getmembers():
+                    member_path = os.path.join(path, member.name)
+                    if not is_within_directory(path, member_path):
+                        raise Exception("Attempted Path Traversal in Tar File")
+            
+                tar.extractall(path, members, numeric_owner=numeric_owner) 
+                
+            
+            safe_extract(tar)
         pickle_filename = glob.glob('*.pickle')[0]
         # 'New' format (Spyder >=2.2 for Python 2 and Python 3)
         with open(pickle_filename, 'rb') as fdesc:


### PR DESCRIPTION
From the original pull request (i.e. PR #424):

## Patching CVE-2007-4559

Hi, we are security researchers from the Advanced Research Center at [Trellix](https://www.trellix.com). We have began a campaign to patch a widespread bug named CVE-2007-4559. CVE-2007-4559 is a 15 year old bug in the Python tarfile package. By using extract() or extractall() on a tarfile object without sanitizing input, a maliciously crafted .tar file could perform a directory path traversal attack. We found at least one unsantized extractall() in your codebase and are providing a patch for you via pull request. The patch essentially checks to see if all tarfile members will be extracted safely and throws an exception otherwise. We encourage you to use this patch or your own solution to secure against CVE-2007-4559. Further technical information about the vulnerability can be found in this [blog](https://www.trellix.com/en-us/about/newsroom/stories/research/tarfile-exploiting-the-world.html).

If you have further questions you may contact us through this projects lead researcher [Kasimir Schulz](mailto:kasimir.schulz@trellix.com).
