### PR TITLE
PR: Replace deprecated `inspect.formatargspec` call

### DIFF
--- a/spyder_kernels/utils/dochelpers.py
+++ b/spyder_kernels/utils/dochelpers.py
@@ -120,11 +120,8 @@ def getdoc(obj):
                     args, varargs, varkw, defaults,
                     formatvalue=lambda o:'='+repr(o))
             else:
-                (args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-                 annotations) = inspect.getfullargspec(obj)
-                doc['argspec'] = inspect.formatargspec(
-                    args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-                    annotations, formatvalue=lambda o:'='+repr(o))
+                sig = inspect.signature(obj)
+                doc['argspec'] = str(sig)
             if name == '<lambda>':
                 doc['name'] = name + ' lambda '
                 doc['argspec'] = doc['argspec'][1:-1] # remove parentheses


### PR DESCRIPTION
I have based this patch on the 2.x branch rather than the master branch; the patch would need the obvious modification to apply there (dedenting and changing the surrounding context).

Fixes #307