### PR TITLE
replacing formatargspec() per inspect.signature()

### DIFF
--- a/spyder_kernels/utils/dochelpers.py
+++ b/spyder_kernels/utils/dochelpers.py
@@ -110,11 +110,7 @@ def getdoc(obj):
             doc['note'] = 'Function'
         doc['name'] = obj.__name__
         if inspect.isfunction(obj):
-            (args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-             annotations) = inspect.getfullargspec(obj)
-            doc['argspec'] = inspect.formatargspec(
-                args, varargs, varkw, defaults, kwonlyargs, kwonlydefaults,
-                annotations, formatvalue=lambda o: '='+repr(o))
+            doc['argspec'] = str(inspect.signature(obj))
             if name == '<lambda>':
                 doc['name'] = name + ' lambda '
                 doc['argspec'] = doc['argspec'][1:-1] # remove parentheses


### PR DESCRIPTION
The formatargspec() function is deprecated since Python 3.5, and removed in Python-3.11
It would be nice to have a fix in coming Spyder-5.4.2


## Description of Changes

* I replace The formatargspec() function, deprecated since Python 3.5; per [inspect.signature()](https://docs.python.org/3/library/inspect.html#inspect.signature)
* I checked on lambda and not lambda 
![image](https://user-images.githubusercontent.com/4312421/211160182-f62a2483-c2de-4b2c-b9e5-08df9612df33.png)

![image](https://user-images.githubusercontent.com/4312421/211160206-55bf882d-e820-454f-a7af-a9c30ff4a7d8.png)

