### PR TITLE
PR: Remove imports from __future__

### DIFF
--- a/spyder_kernels/comms/commbase.py
+++ b/spyder_kernels/comms/commbase.py
@@ -50,8 +50,6 @@ The messages exchanged are:
                 'call_name': The function name (mostly for debugging)
                 }
 """
-from __future__ import print_function
-
 import cloudpickle
 import pickle
 import logging

--- a/spyder_kernels/utils/dochelpers.py
+++ b/spyder_kernels/utils/dochelpers.py
@@ -7,9 +7,6 @@
 # -----------------------------------------------------------------------------
 
 """Utilities and wrappers around inspect module"""
-
-from __future__ import print_function
-
 import builtins
 import inspect
 import re

--- a/spyder_kernels/utils/iofuncs.py
+++ b/spyder_kernels/utils/iofuncs.py
@@ -12,9 +12,6 @@ Input/Output Utilities
 Note: 'load' functions has to return a dictionary from which a globals()
       namespace may be updated
 """
-
-from __future__ import print_function
-
 # Standard library imports
 import sys
 import os

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -9,9 +9,6 @@
 """
 Utilities to build a namespace view.
 """
-
-from __future__ import print_function
-
 from itertools import islice
 import inspect
 import re


### PR DESCRIPTION
It seems like PY2 is still in 2.x, but not master, so I guess that master is the correct branch to target for this?

Just a minor cleanup.