### PR TITLE
Add FreeBSD to test user site-packages in pathlist

### DIFF
--- a/spyder_kernels/customize/tests/test_utils.py
+++ b/spyder_kernels/customize/tests/test_utils.py
@@ -16,7 +16,7 @@ def test_user_sitepackages_in_pathlist():
     """Test that we include user site-packages in pathlist."""
     if sys.platform.startswith('linux'):
         user_path = 'local'
-    elif (sys.platform.startswith('darwin') | sys.platform.startswith('freebsd')):
+    elif (sys.platform = 'darwin' or sys.platform.startswith('freebsd')):
         user_path = os.path.expanduser('~/.local')
     else:
         user_path = 'Roaming'

--- a/spyder_kernels/customize/tests/test_utils.py
+++ b/spyder_kernels/customize/tests/test_utils.py
@@ -16,7 +16,7 @@ def test_user_sitepackages_in_pathlist():
     """Test that we include user site-packages in pathlist."""
     if sys.platform.startswith('linux'):
         user_path = 'local'
-    elif sys.platform == 'darwin':
+    elif (sys.platform.startswith('darwin') | sys.platform.startswith('freebsd')):
         user_path = os.path.expanduser('~/.local')
     else:
         user_path = 'Roaming'


### PR DESCRIPTION
This is the only one of the test suite that FreeBSD does not pass, it was not recognized. Since FreeBSD uses the same path as Darwin, it can simply be appended to the if statement.