### PR TITLE
PR: Add FreeBSD to `test_user_sitepackages_in_pathlist`

### DIFF
--- a/spyder_kernels/customize/tests/test_utils.py
+++ b/spyder_kernels/customize/tests/test_utils.py
@@ -16,7 +16,7 @@ def test_user_sitepackages_in_pathlist():
     """Test that we include user site-packages in pathlist."""
     if sys.platform.startswith('linux'):
         user_path = 'local'
-    elif sys.platform == 'darwin':
+    elif (sys.platform == 'darwin' or sys.platform.startswith('freebsd'):
         user_path = os.path.expanduser('~/.local')
     else:
         user_path = 'Roaming'

--- a/spyder_kernels/customize/tests/test_utils.py
+++ b/spyder_kernels/customize/tests/test_utils.py
@@ -16,7 +16,7 @@ def test_user_sitepackages_in_pathlist():
     """Test that we include user site-packages in pathlist."""
     if sys.platform.startswith('linux'):
         user_path = 'local'
-    elif (sys.platform == 'darwin' or sys.platform.startswith('freebsd'):
+    elif (sys.platform == 'darwin' or sys.platform.startswith('freebsd')):
         user_path = os.path.expanduser('~/.local')
     else:
         user_path = 'Roaming'


### PR DESCRIPTION
The 'user site-packages in pathlist' test is the only one that fails on FreeBSD because the OS is not recognized. FreeBSD uses the same .local path as Darwin, so you can simply extend the if statement.