### PR TITLE
PR: Remove unnecessary code for old IPykernel versions in our tests

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -11,6 +11,7 @@ Tests for the console kernel.
 
 # Standard library imports
 import ast
+import asyncio
 import os
 import os.path as osp
 from textwrap import dedent
@@ -23,7 +24,6 @@ import uuid
 from collections import namedtuple
 
 # Test imports
-import ipykernel
 import pytest
 from flaky import flaky
 from jupyter_core import paths
@@ -37,17 +37,10 @@ from spyder_kernels.utils.test_utils import get_kernel, get_log_text
 from spyder_kernels.customize.spyderpdb import SpyderPdb
 from spyder_kernels.comms.commbase import CommBase
 
-# For ipykernel 6
-try:
-    import asyncio
-except ImportError:
-    pass
-
 # =============================================================================
 # Constants and utility functions
 # =============================================================================
 FILES_PATH = os.path.dirname(os.path.realpath(__file__))
-IPYKERNEL_6 = ipykernel.__version__[0] >= '6'
 TIMEOUT = 15
 SETUP_TIMEOUT = 60
 
@@ -239,10 +232,7 @@ def kernel(request):
 
     # Teardown
     def reset_kernel():
-        if IPYKERNEL_6:
-            asyncio.run(kernel.do_execute('reset -f', True))
-        else:
-            kernel.do_execute('reset -f', True)
+        asyncio.run(kernel.do_execute('reset -f', True))
     request.addfinalizer(reset_kernel)
 
     return kernel
@@ -287,10 +277,7 @@ def test_get_namespace_view(kernel):
     """
     Test the namespace view of the kernel.
     """
-    if IPYKERNEL_6:
-        execute = asyncio.run(kernel.do_execute('a = 1', True))
-    else:
-        execute = kernel.do_execute('a = 1', True)
+    execute = asyncio.run(kernel.do_execute('a = 1', True))
 
     nsview = repr(kernel.get_namespace_view())
     assert "'a':" in nsview
@@ -305,10 +292,7 @@ def test_get_var_properties(kernel):
     """
     Test the properties fo the variables in the namespace.
     """
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute('a = 1', True))
-    else:
-        kernel.do_execute('a = 1', True)
+    asyncio.run(kernel.do_execute('a = 1', True))
 
     var_properties = repr(kernel.get_var_properties())
     assert "'a'" in var_properties
@@ -326,10 +310,7 @@ def test_get_var_properties(kernel):
 def test_get_value(kernel):
     """Test getting the value of a variable."""
     name = 'a'
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute("a = 124", True))
-    else:
-        kernel.do_execute("a = 124", True)
+    asyncio.run(kernel.do_execute("a = 124", True))
 
     # Check data type send
     assert kernel.get_value(name) == 124
@@ -338,10 +319,7 @@ def test_get_value(kernel):
 def test_set_value(kernel):
     """Test setting the value of a variable."""
     name = 'a'
-    if IPYKERNEL_6:
-         asyncio.run(kernel.do_execute('a = 0', True))
-    else:
-        kernel.do_execute('a = 0', True)
+    asyncio.run(kernel.do_execute('a = 0', True))
     value = 10
     kernel.set_value(name, value)
     log_text = get_log_text(kernel)
@@ -355,10 +333,7 @@ def test_set_value(kernel):
 def test_remove_value(kernel):
     """Test the removal of a variable."""
     name = 'a'
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute('a = 1', True))
-    else:
-        kernel.do_execute('a = 1', True)
+    asyncio.run(kernel.do_execute('a = 1', True))
 
     var_properties = repr(kernel.get_var_properties())
     assert "'a'" in var_properties
@@ -380,10 +355,7 @@ def test_copy_value(kernel):
     """Test the copy of a variable."""
     orig_name = 'a'
     new_name = 'b'
-    if IPYKERNEL_6:
-         asyncio.run(kernel.do_execute('a = 1', True))
-    else:
-        kernel.do_execute('a = 1', True)
+    asyncio.run(kernel.do_execute('a = 1', True))
 
     var_properties = repr(kernel.get_var_properties())
     assert "'a'" in var_properties
@@ -419,11 +391,7 @@ def test_load_npz_data(kernel, load):
     namespace_file = osp.join(FILES_PATH, 'load_data.npz')
     extention = '.npz'
     overwrite, execute, variables = load
-
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute(execute, True))
-    else:
-        kernel.do_execute(execute, True)
+    asyncio.run(kernel.do_execute(execute, True))
 
     kernel.load_data(namespace_file, extention, overwrite=overwrite)
     for var, value in variables.items():
@@ -451,11 +419,7 @@ def test_load_data(kernel):
 def test_save_namespace(kernel):
     """Test saving the namespace into filename."""
     namespace_file = osp.join(FILES_PATH, 'save_data.spydata')
-
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute('b = 1', True))
-    else:
-        kernel.do_execute('b = 1', True)
+    asyncio.run(kernel.do_execute('b = 1', True))
 
     kernel.save_namespace(namespace_file)
     assert osp.isfile(namespace_file)
@@ -499,11 +463,7 @@ libc.printf(('Hello from C\\n').encode('utf8'))
 
     # With Wurlitzer we have the expected output
     kernel._load_wurlitzer()
-
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute(code, True))
-    else:
-        kernel.do_execute(code, True)
+    asyncio.run(kernel.do_execute(code, True))
     captured = capsys.readouterr()
     assert captured.out == "Hello from C\n"
 
@@ -616,7 +576,7 @@ if __name__ == '__main__':
 
 
 @flaky(max_runs=3)
-@pytest.mark.skipif(not PY3, reason="Only meant for Python 3")
+@pytest.mark.skipif(
     sys.platform == 'darwin' and sys.version_info[:2] == (3, 8),
     reason="Fails on Mac with Python 3.8")
 @pytest.mark.skipif(
@@ -892,10 +852,7 @@ def test_do_complete(kernel):
     """
     Check do complete works in normal and debugging mode.
     """
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute('abba = 1', True))
-    else:
-        kernel.do_execute('abba = 1', True)
+    asyncio.run(kernel.do_execute('abba = 1', True))
     assert kernel.get_value('abba') == 1
     match = kernel.do_complete('ab', 2)
     assert 'abba' in match['matches']
@@ -918,17 +875,11 @@ def test_callables_and_modules(kernel, exclude_callables_and_modules,
     Tests that callables and modules are in the namespace view only
     when the right options are passed to the kernel.
     """
-    if IPYKERNEL_6:
-        asyncio.run(kernel.do_execute('import numpy', True))
-        asyncio.run(kernel.do_execute('a = 10', True))
-        asyncio.run(kernel.do_execute('def f(x): return x', True))
-    else:
-        kernel.do_execute('import numpy', True)
-        kernel.do_execute('a = 10', True)
-        kernel.do_execute('def f(x): return x', True)
+    asyncio.run(kernel.do_execute('import numpy', True))
+    asyncio.run(kernel.do_execute('a = 10', True))
+    asyncio.run(kernel.do_execute('def f(x): return x', True))
 
     settings = kernel.namespace_view_settings
-
     settings['exclude_callables_and_modules'] = exclude_callables_and_modules
     settings['exclude_unsupported'] = exclude_unsupported
     nsview = kernel.get_namespace_view()

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1119,6 +1119,7 @@ def test_locals_globals_in_pdb(kernel):
 @pytest.mark.skipif(
     sys.version_info[:2] < (3, 9),
     reason="Too flaky in Python 3.7/8 and doesn't work in older versions")
+@pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
 def test_get_interactive_backend(backend):
     """
     Test that we correctly get the interactive backend set in the kernel.


### PR DESCRIPTION
This also fixes our tests in `master`.