### PR TITLE
PR: Disable IPython's debugger skip functionality by default

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -109,6 +109,17 @@ class SpyderPdb(ipyPdb, object):  # Inherits `object` to call super() in PY2
         # Line received from the frontend
         self._cmd_input_line = None
 
+        # This is not available in IPython 5
+        if hasattr(self, '_predicates'):
+            # Turn off IPython's debugger skip funcionality by default because
+            # it makes our debugger quite slow. It's also important to remark
+            # that this functionality doesn't do anything on its own. Users
+            # need to mark what frames they want to skip for it to be useful.
+            # So, we hope that knowledgeable users will find that they need to
+            # enable it in Spyder.
+            # Fixes spyder-ide/spyder#20639.
+            self._predicates["debuggerskip"] = False
+
     # --- Methods overriden for code execution
     def print_exclamation_warning(self):
         """Print pdb warning for exclamation mark."""


### PR DESCRIPTION
This is necessary to solve spyder-ide/spyder#20639 and partly for spyder-ide/spyder#20571 too.