### PR TITLE
PR: Increase minimal required version of IPykernel to 6.23.2

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,5 +1,5 @@
 cloudpickle
-ipykernel>=6.16.1,<7
+ipykernel>=6.23.2,<7
 ipython>=7.31.1,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=22.1.0

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,5 @@
 cloudpickle
-ipykernel>=6.16.1,<7
+ipykernel>=6.23.2,<7
 ipython>=7.31.1,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=22.1.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIREMENTS = [
     'backports.functools-lru-cache; python_version<"3"',
     'cloudpickle',
     'ipykernel>=4.5,<5; python_version<"3"',
-    'ipykernel>=6.16.1,<7; python_version>="3"',
+    'ipykernel>=6.23.2,<7; python_version>="3"',
     'ipython<6; python_version<"3"',
     'ipython>=7.31.1,<9,!=8.8.0,!=8.9.0,!=8.10.0,!=8.11.0,!=8.12.0,!=8.12.1; python_version>="3"',
     'jupyter-client>=5.3.4,<6; python_version<"3"',


### PR DESCRIPTION
This is necessary to address spyder-ide/spyder#21017.