### PR TITLE
Save temporary file in test to temporary location

### DIFF
--- a/spyder_kernels/utils/tests/test_iofuncs.py
+++ b/spyder_kernels/utils/tests/test_iofuncs.py
@@ -340,13 +340,14 @@ def test_spydata_export(input_namespace, expected_namespace,
                 pass
 
 
-def test_save_load_hdf5_files():
+def test_save_load_hdf5_files(tmp_path):
     """Simple test to check that we can save and load HDF5 files."""
+    h5_file = tmp_path / "test.h5"
     data = {'a' : [1, 2, 3, 4], 'b' : 4.5}
-    iofuncs.save_hdf5(data, "test.h5")
+    iofuncs.save_hdf5(data, h5_file)
 
     expected = ({'a': np.array([1, 2, 3, 4]), 'b': np.array(4.5)}, None)
-    assert repr(iofuncs.load_hdf5("test.h5")) == repr(expected)
+    assert repr(iofuncs.load_hdf5(h5_file)) == repr(expected)
 
 
 def test_load_dicom_files():


### PR DESCRIPTION
The test `test_save_load_hdf5_files` saves its test file `test.h5` in the current directory, which is not helpful.  (If you run the tests prior to installing the package, the h5 file may end up in the resulting package, for example.)

This patch saves the `test.h5` in a temporary directory instead.