### PR TITLE
PR: Improve getting signatures from text

### DIFF
--- a/spyder_kernels/utils/tests/test_dochelpers.py
+++ b/spyder_kernels/utils/tests/test_dochelpers.py
@@ -139,5 +139,22 @@ def test_multisignature():
     assert signature == "(x, y)"
 
 
+def test_multiline_signature():
+    """
+    Test that we can get signatures splitted into multiple lines in a
+    docstring.
+    """
+    def foo():
+        """
+        foo(x,
+            y)
+
+        This is a docstring.
+        """
+
+    signature = getargspecfromtext(foo.__doc__)
+    assert signature.startswith("(x, ")
+
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
- Discard IPython default signatures in case we're able to find others.
- Get signatures written in multiple lines at the beginning of docstrings.