### PR TITLE
PR: Fix hangs with Maplotlib interactive backends

### DIFF
--- a/.github/workflows/linux-pip-tests.yml
+++ b/.github/workflows/linux-pip-tests.yml
@@ -46,8 +46,10 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install -e .[test]
-          # Zict 2.1.0 is not compatible with Python 3
-          pip install zict==2.0.0
+          # Zict >2.0.0 is not compatible with Python 3
+          if [ "$PYTHON_VERSION" = "2.7" ]; then
+            pip install zict==2.0.0
+          fi
       - name: Show environment information
         shell: bash -l {0}
         run: |

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          if [ "$PYTHON_VERSION" != "2.7" ]; then mamba install --file requirements/posix.txt -y -q; else mamba install --file requirements/python-27.txt -y -q; fi
+          mamba install --file requirements/posix.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
         run: mamba install --file requirements/tests.txt -y -q

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          if [ "$PYTHON_VERSION" != "2.7" ]; then mamba install --file requirements/posix.txt -y -q; else mamba install --file requirements/python-27.txt -y -q; fi
+          mamba install --file requirements/posix.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
         run: mamba install --file requirements/tests.txt -y -q

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,5 +1,5 @@
 cloudpickle
-ipykernel>=6.23.2,<7
+ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=22.1.0

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -2,5 +2,5 @@ cloudpickle
 ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
-pyzmq>=22.1.0
+pyzmq>=24.0.0
 wurlitzer>=1.0.3

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,5 +1,5 @@
 cloudpickle
-ipykernel>=6.23.2,<7
+ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=22.1.0

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -2,4 +2,4 @@ cloudpickle
 ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
-pyzmq>=22.1.0
+pyzmq>=24.0.0

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIREMENTS = [
     'cloudpickle',
     'ipykernel>=4.5,<5; python_version<"3"',
     'ipykernel>=6.16.1,<6.17; python_version<"3.8"',
-    'ipykernel>=6.23.2,<7; python_version>="3.8"',
+    'ipykernel>=6.29.3,<7; python_version>="3.8"',
     'ipython<6; python_version<"3"',
     'ipython>=7.31.1,<8; python_version<"3.8"',
     'ipython>=8.12.2,<8.13; python_version=="3.8"',

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ REQUIREMENTS = [
     'jupyter-client>=5.3.4,<6; python_version<"3"',
     'jupyter-client>=7.4.9,<9; python_version>="3"',
     'pyzmq>=17,<20; python_version<"3"',
-    'pyzmq>=22.1.0; python_version>="3"',
+    'pyzmq>=24.0.0; python_version>="3"',
     'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 


### PR DESCRIPTION
- Addresses spyder-ide/spyder#21299.
- This requires updating our dependency on IPykernel to `>=6.29.3,<7`.