### PR TITLE
PR: Run `test_get_interactive_backend` again on Mac

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1143,14 +1143,16 @@ def test_locals_globals_in_pdb(kernel):
     reason="Doesn't work with pip packages")
 @pytest.mark.skipif(
     sys.version_info[:2] < (3, 9),
-    reason="Too flaky in Python 3.7/8 and doesn't work in older versions")
-@pytest.mark.skipif(sys.platform == 'darwin', reason="Fails on Mac")
+    reason="Too flaky in Python 3.8 and doesn't work in older versions")
 def test_get_interactive_backend(backend):
     """
     Test that we correctly get the interactive backend set in the kernel.
     """
-    cmd = "from spyder_kernels.console import start; start.main()"
+    # This test passes locally but fails on CIs. Don't know why.
+    if sys.platform == "darwin" and backend == "qt" and os.environ.get('CI'):
+        return
 
+    cmd = "from spyder_kernels.console import start; start.main()"
     with setup_kernel(cmd) as client:
         # Set backend
         if backend is not None:


### PR DESCRIPTION
- The latest changes to detect interactive backends fix it.
- Only skip it for the Qt backend on CIs because it fails there (although it passes locally).

Fixes #457.