### PR TITLE
PR: Fix issue where Spyder's inline graphics preferences were not applied

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -950,10 +950,13 @@ class SpyderKernel(IPythonKernel):
         """
         Update InlineBackend given an option and value.
 
-        As parameters:
-            option: config option; one of 'close_figures', 'figure_formats',
-                'print_figure_kwargs', or 'rc'.
-            value: value of the option
+        Parameters
+        ----------
+        option: str
+            Configuration option. One of 'close_figures', 'figure_formats',
+            'print_figure_kwargs', or 'rc'.
+        value: str | dict
+            Value of the option.
         """
         if (
             'InlineBackend' in self.config
@@ -976,10 +979,13 @@ class SpyderKernel(IPythonKernel):
         if option == 'rc' and self.get_matplotlib_backend() == 'inline':
             # Explicitly update rcParams if already in inline mode so that
             # new settings are effective immediately.
-            import matplotlib
-            matplotlib.rcParams.update(value)
+            try:
+                import matplotlib
+                matplotlib.rcParams.update(value)
+            except Exception:
+                pass
 
-    def _restore_rc_file_defaults(self):
+    def restore_rc_file_defaults(self):
         """Restore inline rcParams to file defaults"""
         try:
             import matplotlib

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -585,23 +585,21 @@ class SpyderKernel(IPythonKernel):
         # the rcParams and restores rcParams when switching to interactive.
         interactive_backend = self.get_mpl_interactive_backend()
         current_backend = self.get_matplotlib_backend()
-        pylab_changed = pylab_autoload_n in conf
-        backend_changed = pylab_backend_n in conf
+        pylab_autoload_o = conf.get(pylab_autoload_n, False)
+        pylab_backend_o = conf.get(pylab_backend_n, current_backend)
+        backend_changed = current_backend != pylab_backend_o
         if (
-            current_backend == 'inline'
+            current_backend == 'inline' and rc
             and not backend_changed
             and interactive_backend not in ('inline', -1)
         ):
             self._set_mpl_backend(interactive_backend)
         if (
-            current_backend == 'inline'  # toggle back to inline for rcParams
-            or pylab_changed
+            (current_backend == 'inline' and rc)  # toggle back to inline
+            or pylab_autoload_o
             or backend_changed
         ):
-            self._set_mpl_backend(
-                conf.get(pylab_backend_n, current_backend),
-                pylab=conf.get(pylab_autoload_n, False)
-            )
+            self._set_mpl_backend(pylab_backend_o, pylab_autoload_o)
 
     # -- For completions
     def set_jedi_completer(self, use_jedi):

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -888,9 +888,9 @@ class SpyderKernel(IPythonKernel):
             return
 
         generic_error = (
-            "\n" + "="*73 + "\n"
+            "\n" + "=" * 73 + "\n"
             "NOTE: The following error appeared when setting "
-            "your Matplotlib backend!!\n" + "="*73 + "\n\n"
+            "your Matplotlib backend!!\n" + "=" * 73 + "\n\n"
             "{0}"
         )
 
@@ -912,7 +912,7 @@ class SpyderKernel(IPythonKernel):
             # trying to set a backend. See issue 5541
             if "GUI eventloops" in str(err):
                 previous_backend = matplotlib.get_backend()
-                if not backend in previous_backend.lower():
+                if backend not in previous_backend.lower():
                     # Only inform about an error if the user selected backend
                     # and the one set by Matplotlib are different. Else this
                     # message is very confusing.

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -557,7 +557,7 @@ class SpyderKernel(IPythonKernel):
 
         if figure_format_n in conf:
             self._set_inline_config_option(
-                'figure_format', conf[figure_format_n]
+                'figure_formats', conf[figure_format_n]
             )
 
         rc = {}
@@ -945,7 +945,7 @@ class SpyderKernel(IPythonKernel):
         Set config options using the %config magic.
 
         As parameters:
-            option: config option, for example 'InlineBackend.figure_format'.
+            option: config option, for example 'InlineBackend.figure_formats'.
             value: value of the option, for example 'SVG', 'Retina', etc.
         """
         try:

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -560,17 +560,21 @@ class SpyderKernel(IPythonKernel):
                 'figure_formats', conf[figure_format_n]
             )
 
-        rc = {}
+        inline_rc = {}
         if resolution_n in conf:
-            rc.update({'figure.dpi': conf[resolution_n]})
+            inline_rc.update({'figure.dpi': conf[resolution_n]})
         if width_n in conf or height_n in conf:
-            rc.update({'figure.figsize': (conf[width_n], conf[height_n])})
+            inline_rc.update(
+                {'figure.figsize': (conf[width_n], conf[height_n])}
+            )
         if fontsize_n in conf:
-            rc.update({'font.size': conf[fontsize_n]})
+            inline_rc.update({'font.size': conf[fontsize_n]})
         if bottom_n in conf:
-            rc.update({'figure.subplot.bottom': conf[bottom_n]})
-        if rc:
-            self._set_inline_config_option('rc', rc)
+            inline_rc.update({'figure.subplot.bottom': conf[bottom_n]})
+
+        # Update Inline backend parameters, if available.
+        if inline_rc:
+            self._set_inline_config_option('rc', inline_rc)
 
         if bbox_inches_n in conf:
             bbox_inches = 'tight' if conf[bbox_inches_n] else None
@@ -589,13 +593,13 @@ class SpyderKernel(IPythonKernel):
         pylab_backend_o = conf.get(pylab_backend_n, current_backend)
         backend_changed = current_backend != pylab_backend_o
         if (
-            current_backend == 'inline' and rc
+            current_backend == 'inline' and inline_rc
             and not backend_changed
             and interactive_backend not in ('inline', -1)
         ):
             self._set_mpl_backend(interactive_backend)
         if (
-            (current_backend == 'inline' and rc)  # toggle back to inline
+            (current_backend == 'inline' and inline_rc)  # toggle back to inline
             or pylab_autoload_o
             or backend_changed
         ):
@@ -976,6 +980,7 @@ class SpyderKernel(IPythonKernel):
             self.config['InlineBackend'].update({option: value})
         else:
             self.config.update({'InlineBackend': Config({option: value})})
+
         value = self.config['InlineBackend'][option]
 
         if isinstance(value, LazyConfigValue):

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -89,6 +89,10 @@ class SpyderShell(ZMQInteractiveShell):
         if gui is None or gui.lower() == "auto":
             gui = automatic_backend()
 
+        # Before activating the backend, restore to file default those
+        # InlineBackend settings that may have been set explicitly.
+        self.kernel._restore_rc_file_defaults()
+
         enabled_gui, backend = super().enable_matplotlib(gui)
 
         # This is necessary for IPython 8.24+, which returns None after

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -91,7 +91,7 @@ class SpyderShell(ZMQInteractiveShell):
 
         # Before activating the backend, restore to file default those
         # InlineBackend settings that may have been set explicitly.
-        self.kernel._restore_rc_file_defaults()
+        self.kernel.restore_rc_file_defaults()
 
         enabled_gui, backend = super().enable_matplotlib(gui)
 

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -93,28 +93,6 @@ def kernel_config():
             "del sys; del pdb"
         )
 
-    # Default inline backend configuration.
-    # This is useful to have when people doesn't
-    # use our config system to configure the
-    # inline backend but want to use
-    # '%matplotlib inline' at runtime
-    spy_cfg.InlineBackend.rc = {
-        # The typical default figure size is too large for inline use,
-        # so we shrink the figure size to 6x4, and tweak fonts to
-        # make that fit.
-        'figure.figsize': (6.0, 4.0),
-        # 72 dpi matches SVG/qtconsole.
-        # This only affects PNG export, as SVG has no dpi setting.
-        'figure.dpi': 72,
-        # 12pt labels get cutoff on 6x4 logplots, so use 10pt.
-        'font.size': 10,
-        # 10pt still needs a little more room on the xlabel
-        'figure.subplot.bottom': .125,
-        # Play nicely with any background color.
-        'figure.facecolor': 'white',
-        'figure.edgecolor': 'white'
-    }
-
     if is_module_installed('matplotlib'):
         spy_cfg.IPKernelApp.matplotlib = "inline"
 


### PR DESCRIPTION
This fixes an issue where:
* Spyder's inline graphics preferences were not applied when toggling from inline to interactive and back to inline.
* Matplotlib's `rcParams` are over-written by Spyder's inline preferences even with the preference set for an interactive backend.

For more detail, see spyder-ide/spyder#22034.