### PR TITLE
Accommodate Matplotlib 3.9.0 in spyder-kernels 3.x

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -498,7 +498,7 @@ class SpyderKernel(IPythonKernel):
         """Get current matplotlib backend."""
         try:
             import matplotlib
-            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend()]
+            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend().lower()]
         except Exception:
             return None
 

--- a/spyder_kernels/utils/mpl.py
+++ b/spyder_kernels/utils/mpl.py
@@ -20,11 +20,12 @@ else:
 
 # Mapping of matlotlib backends options to Spyder
 MPL_BACKENDS_TO_SPYDER = {
-    inline_backend: "inline",
-    'Qt5Agg': 'qt',
-    'QtAgg': 'qt',  # For Matplotlib 3.5+
-    'TkAgg': 'tk',
-    'MacOSX': 'osx',
+    'inline': 'inline',  # For Matplotlib >=3.9
+    inline_backend: "inline",  # For Matplotlib <3.9
+    'qt5agg': 'qt',
+    'qtagg': 'qt',  # For Matplotlib 3.5+
+    'tkagg': 'tk',
+    'macosx': 'osx',
 }
 
 


### PR DESCRIPTION
Matplotlib `get_backend` returns lowercase in version >=3.9.0.
Update `MPL_BACKENDS_TO_SPYDER` to accommodate.