### PR TITLE
PR: Fix detecting Matplotlib backend for its 3.9.0 version

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -382,7 +382,7 @@ class SpyderKernel(IPythonKernel):
         """Get current matplotlib backend."""
         try:
             import matplotlib
-            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend()]
+            return MPL_BACKENDS_TO_SPYDER[matplotlib.get_backend().lower()]
         except Exception:
             return None
 
@@ -428,7 +428,7 @@ class SpyderKernel(IPythonKernel):
             # equivalent to having the inline one.
             return 0
         elif framework in mapping:
-            return MPL_BACKENDS_TO_SPYDER[mapping[framework]]
+            return MPL_BACKENDS_TO_SPYDER[mapping[framework].lower()]
         else:
             # This covers the case of other backends (e.g. Wx or Gtk)
             # which users can set interactively with the %matplotlib

--- a/spyder_kernels/utils/mpl.py
+++ b/spyder_kernels/utils/mpl.py
@@ -27,11 +27,12 @@ else:
 
 # Mapping of matlotlib backends options to Spyder
 MPL_BACKENDS_TO_SPYDER = {
-    inline_backend: 0,
-    'Qt5Agg': 2,
-    'QtAgg': 2,  # For Matplotlib 3.5+
-    'TkAgg': 3,
-    'MacOSX': 4,
+    'inline': 0,  # For Matplotlib >=3.9
+    inline_backend: 0,  # For Matplotlib <3.9
+    'qt5agg': 2,
+    'qtagg': 2,  # For Matplotlib 3.5+
+    'tkagg': 3,
+    'macosx': 4,
 }
 
 


### PR DESCRIPTION
Matplotlib get_backend returns lowercase in version >=3.9.0.
Update MPL_BACKENDS_TO_SPYDER to accommodate.