### PR TITLE
PR: Resolve possible macOS application bundle symlink

### DIFF
--- a/spyder_kernels/utils/pythonenv.py
+++ b/spyder_kernels/utils/pythonenv.py
@@ -53,7 +53,8 @@ def get_conda_env_path(pyexec, quote=False):
     if os.name == 'nt':
         conda_env = os.path.dirname(pyexec)
     else:
-        conda_env = os.path.dirname(os.path.dirname(pyexec))
+        # Resolve possible symlink in case of macOS application bundle
+        conda_env = os.path.dirname(os.path.dirname(os.path.realpath(pyexec)))
 
     if quote:
         conda_env = add_quotes(conda_env)


### PR DESCRIPTION
If pyexec is not a symlink, nothing will change. If pyexec is a symlink and in a conda environment, then the symlink will resolve to pythonX.XX in the same directory, so the result of get_conda_env_path will be the same. If pyexec is a symlink that is neither in a conda environment nor in a macOS application bundle, then the result get_conda_env_path may be different, but it wasn't a conda environment anyway.