### PR TITLE
PR: Update workflow actions (CI)

### DIFF
--- a/.github/workflows/linux-pip-tests.yml
+++ b/.github/workflows/linux-pip-tests.yml
@@ -24,7 +24,7 @@ jobs:
       RUNNER_OS: 'ubuntu'
       USE_CONDA: 'false'
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 20
@@ -32,16 +32,16 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v1
       - name: Install System Packages
-        run: | 
+        run: |
           sudo apt-get update
           sudo apt-get install libegl1-mesa libopengl0
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: false
            auto-activate-base: false
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package and dependencies
         shell: bash -l {0}
         run: |
@@ -61,7 +61,7 @@ jobs:
           xvfb-run --auto-servernum pytest spyder_kernels --color=yes --cov=spyder_kernels -vv || \
           xvfb-run --auto-servernum pytest spyder_kernels --color=yes --cov=spyder_kernels -vv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -42,15 +42,14 @@ jobs:
            auto-update-conda: true
            auto-activate-base: false
            channels: conda-forge
-           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          mamba install --file requirements/posix.txt -y -q
+          conda install --file requirements/posix.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
-        run: mamba install --file requirements/tests.txt -y -q
+        run: conda install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -24,7 +24,7 @@ jobs:
       RUNNER_OS: 'ubuntu'
       USE_CONDA: 'true'
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 20
@@ -32,18 +32,18 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v1
       - name: Install System Packages
-        run: | 
+        run: |
           sudo apt-get update
           sudo apt-get install libegl1-mesa libopengl0
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
            channels: conda-forge
            miniforge-variant: Mambaforge
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
@@ -69,7 +69,7 @@ jobs:
           xvfb-run --auto-servernum pytest spyder_kernels --color=yes --cov=spyder_kernels -vv || \
           xvfb-run --auto-servernum pytest spyder_kernels --color=yes --cov=spyder_kernels -vv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -38,15 +38,14 @@ jobs:
            auto-update-conda: true
            auto-activate-base: false
            channels: conda-forge
-           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
-          mamba install --file requirements/posix.txt -y -q
+          conda install --file requirements/posix.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
-        run: mamba install --file requirements/tests.txt -y -q
+        run: conda install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -24,7 +24,7 @@ jobs:
       RUNNER_OS: 'macos'
       USE_CONDA: 'true'
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 25
@@ -32,14 +32,14 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v1
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: true
            auto-activate-base: false
            channels: conda-forge
            miniforge-variant: Mambaforge
-           python-version: ${{ matrix.PYTHON_VERSION }} 
+           python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
         run: |
@@ -65,7 +65,7 @@ jobs:
           pytest spyder_kernels --color=yes --cov=spyder_kernels -vv || \
           pytest spyder_kernels --color=yes --cov=spyder_kernels -vv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -24,7 +24,7 @@ jobs:
       RUNNER_OS: 'windows'
       USE_CONDA: 'true'
     strategy:
-      fail-fast: false 
+      fail-fast: false
       matrix:
         PYTHON_VERSION: ['3.8', '3.9', '3.10']
     timeout-minutes: 25
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v1
       - name: Install Conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
            activate-environment: test
            auto-update-conda: true
@@ -65,7 +65,7 @@ jobs:
           pytest spyder_kernels --color=yes --cov=spyder_kernels -vv || \
           pytest spyder_kernels --cov=spyder_kernels -vv
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -38,15 +38,14 @@ jobs:
            auto-update-conda: true
            auto-activate-base: false
            channels: conda-forge
-           miniforge-variant: Mambaforge
            python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Install package dependencies
         shell: bash -l {0}
-        run: mamba install --file requirements/windows.txt -y -q
+        run: conda install --file requirements/windows.txt -y -q
       - name: Install test dependencies
         shell: bash -l {0}
         run: |
-          mamba install --file requirements/tests.txt -y -q
+          conda install --file requirements/tests.txt -y -q
       - name: Install Package
         shell: bash -l {0}
         run: pip install -e .


### PR DESCRIPTION
* Update to `setup-miniconda@v3` and `codecov-action@v4`.
  Resolves "The following actions use a deprecated Node.js version and will be forced to run on node20: conda-incubator/setup-miniconda@v2, codecov/codecov-action@v3"