### PR TITLE
PR: Update workflows to run in the `3.x` branch (CI)

### DIFF
--- a/.github/workflows/linux-pip-tests.yml
+++ b/.github/workflows/linux-pip-tests.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
     - master
-    - 2.*
+    - 3.*
   pull_request:
     branches:
     - master
-    - 2.*
+    - 3.*
 
 concurrency:
   group: linux-pip-tests-${{ github.ref }}

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
     - master
-    - 2.*
+    - 3.*
   pull_request:
     branches:
     - master
-    - 2.*
+    - 3.*
 
 concurrency:
   group: linux-tests-${{ github.ref }}

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
     - master
-    - 2.*
+    - 3.*
   pull_request:
     branches:
     - master
-    - 2.*
+    - 3.*
 
 concurrency:
   group: macos-tests-${{ github.ref }}

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
     - master
-    - 2.*
+    - 3.*
   pull_request:
     branches:
     - master
-    - 2.*
+    - 3.*
 
 concurrency:
   group: windows-tests-${{ github.ref }}


### PR DESCRIPTION
This is necessary so we can run our tests for backported PRs.