### PR TITLE
PR: Handle internal  '_pdbcmd'

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -167,7 +167,10 @@ class SpyderPdb(ipyPdb):
                             global_ns[cmd], ZMQExitAutocall):
                         # Use the pdb call
                         cmd_in_namespace = False
-                cmd_func = getattr(self, 'do_' + cmd, None)
+                # Internal pdb command
+                if not cmd.startswith('_pdbcmd'):
+                    cmd = 'do_' + cmd
+                cmd_func = getattr(self, cmd, None)
                 is_pdb_cmd = cmd_func is not None
                 # Look for assignment
                 is_assignment = False


### PR DESCRIPTION
Pdb added internal commands that starts with "_pdbcmd"

fixes https://github.com/spyder-ide/spyder/issues/22500