### PR TITLE
Clarify test error rmessage.

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1314,13 +1314,17 @@ def test_interrupt():
         kernel_comm.remote_call().raise_interrupt_signal()
         # Wait for shell message
         while True:
-            assert time.time() - t0 < 5
+            delta = time.time() - t0
+            assert delta < 5
             msg = client.get_shell_msg(timeout=TIMEOUT)
             if msg["parent_header"].get("msg_id") != msg_id:
                 # not from my request
                 continue
             break
-        assert time.time() - t0 < 5
+        delta = time.time() - t0
+        assert (
+            delta < 5
+        ), "10 second long call should have been interupted, interrupt signal was likely misshandled"
 
 
 def test_enter_debug_after_interruption():


### PR DESCRIPTION
And precompute the delta-time as pytest's:
> assert (1728139272.6514266 - 1728139262.6307526) < 5

Is not super useful to know how long the timeout was.

In particular it allos us to see in ipykernels' main branch that the delta is >=10s, so that the interrupt call is not properly handled.