### PR TITLE
PR: Improve release instructions for the new backporting workflow

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,9 +6,9 @@ To release a new version of spyder-kernels on PyPI:
 
 * git fetch upstream && get merge upstream/3.x
 
-* git clean -xfdi
-
 * Update CHANGELOG.md with `loghub spyder-ide/spyder-kernels -m vX.X.X`
+
+* git clean -xfdi
 
 * Update `_version.py` (set release version, remove 'dev0')
 
@@ -24,15 +24,9 @@ To release a new version of spyder-kernels on PyPI:
 
 * git tag -a vX.X.X -m 'Release X.X.X'
 
-* Update `_version.py` (add 'dev0' and increment minor)
+* Update `_version.py` (add 'dev0' and increment patch)
 
 * git add . && git commit -m 'Back to work'
-
-* git checkout master
-
-* git merge 3.x
-
-* git push upstream master
 
 * git push upstream 3.x
 


### PR DESCRIPTION
Some instructions were not necessary anymore and others needed to be updated.