### PR TITLE
PR: Split `test_interrupt` into two tests

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1308,7 +1308,7 @@ def test_interrupt_short_loop():
         )
 
 
-@pytest.mark.skipif(os.name != "nt", reason="Windows doesn't do 'interrupting sleep'")
+@pytest.mark.skipif(os.name == "nt", reason="Windows doesn't do 'interrupting sleep'")
 def test_interrupt_long_sleep():
     # Command to start the kernel
     cmd = "from spyder_kernels.console import start; start.main()"

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1269,7 +1269,7 @@ def test_debug_namespace(tmpdir):
                     break
 
 
-def test_interrupt():
+def test_interrupt_short_loop():
     """
     Test that the kernel can be interrupted by calling a comm handler.
     """
@@ -1294,17 +1294,35 @@ def test_interrupt():
         kernel_comm.remote_call().raise_interrupt_signal()
         # Wait for shell message
         while True:
-            assert time.time() - t0 < 5
+            delta = time.time() - t0
+            assert delta < 5
             msg = client.get_shell_msg(timeout=TIMEOUT)
             if msg["parent_header"].get("msg_id") != msg_id:
                 # not from my request
                 continue
             break
-        assert time.time() - t0 < 5
+        delta = time.time() - t0
+        assert delta < 5, (
+            "10 seconds long call should have been interrupted, so the "
+            "interrupt signal was likely mishandled"
+        )
 
-        if os.name == 'nt':
-            # Windows doesn't do "interrupting sleep"
-            return
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows doesn't do 'interrupting sleep'")
+def test_interrupt_long_sleep():
+    # Command to start the kernel
+    cmd = "from spyder_kernels.console import start; start.main()"
+    with setup_kernel(cmd) as client:
+        kernel_comm = CommBase()
+
+        # Create new comm and send the highest protocol
+        comm = Comm(kernel_comm._comm_name, client)
+        comm.open(data={})
+        comm._send_channel = client.control_channel
+        kernel_comm._register_comm(comm)
+
+        client.execute_interactive("import time", timeout=TIMEOUT)
+
 
         # Try interrupting sleep
         t0 = time.time()


### PR DESCRIPTION
This is to know if only one or both are failing.
This also properly mark a test as skipped on Windows.

I guess we could make it a parametrize call, but
this would make it complicated to parametrize.