### PR TITLE
PR: Fix some async do completes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © Spyder Kernels Contributors
+# Licensed under the terms of the MIT License
+#
+
+"""
+Main configuration file for Pytest
+"""
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -13,3 +13,4 @@ pillow
 django
 h5py
 pydicom
+anyio

--- a/setup.py
+++ b/setup.py
@@ -47,21 +47,22 @@ REQUIREMENTS = [
 ]
 
 TEST_REQUIREMENTS = [
-    'cython',
-    'dask[distributed]',
-    'flaky',
-    'matplotlib',
-    'mock',
-    'numpy',
-    'pandas',
-    'pytest',
-    'pytest-cov',
-    'scipy',
-    'xarray',
-    'pillow',
-    'django',
-    'h5py',
-    'pydicom'
+    "cython",
+    "dask[distributed]",
+    "flaky",
+    "matplotlib",
+    "mock",
+    "numpy",
+    "pandas",
+    "pytest",
+    "pytest-cov",
+    "scipy",
+    "xarray",
+    "pillow",
+    "django",
+    "h5py",
+    "pydicom",
+    "anyio",
 ]
 
 setup(

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -451,16 +451,19 @@ class SpyderKernel(IPythonKernel):
     # --- For Pdb
     async def _do_complete(self, code, cursor_pos):
         """Call parent class do_complete"""
-        super_method = super(SpyderKernel, self).do_complete
+        super_method = super().do_complete
 
         # handle async def do_comlpete
         if inspect.iscoroutinefunction(super_method):
-            return await method(code, cursor_pos)
-        res = super_method(code, cursor_pos)
+            return await super_method(code, cursor_pos)
+
+        result = super_method(code, cursor_pos)
+
         # handle sync do_complete, returns a Future.
-        if inspect.isawaitable(res):
-            res = await res
-        return res
+        if inspect.isawaitable(result):
+            result = await result
+
+        return result
 
     def do_complete(self, code, cursor_pos):
         """

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -20,6 +20,7 @@ import sys
 import traceback
 import tempfile
 import threading
+import inspect
 import cloudpickle
 
 # Third-party imports
@@ -448,9 +449,18 @@ class SpyderKernel(IPythonKernel):
         return iofunctions.save(data, filename)
 
     # --- For Pdb
-    def _do_complete(self, code, cursor_pos):
+    async def _do_complete(self, code, cursor_pos):
         """Call parent class do_complete"""
-        return super(SpyderKernel, self).do_complete(code, cursor_pos)
+        super_method = super(SpyderKernel, self).do_complete
+
+        # handle async def do_comlpete
+        if inspect.iscoroutinefunction(super_method):
+            return await method(code, cursor_pos)
+        res = super_method(code, cursor_pos)
+        # handle sync do_complete, returns a Future.
+        if inspect.isawaitable(res):
+            res = await res
+        return res
 
     def do_complete(self, code, cursor_pos):
         """

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -900,15 +900,15 @@ def test_matplotlib_inline(kernel):
         # Assert backend is inline
         assert 'inline' in value
 
-
+@pytest.mark.anyio
 async def test_do_complete(kernel):
     """
     Check do complete works in normal and debugging mode.
     """
-    asyncio.run(kernel.do_execute('abba = 1', True))
-    assert kernel.get_value('abba') == 1
-    match = kernel.do_complete('ab', 2)
-    if isawaitable(match):
+    await kernel.do_execute("abba = 1", True)
+    assert kernel.get_value("abba") == 1
+    match = kernel.do_complete("ab", 2)
+    if inspect.isawaitable(match):
         match = await match
     assert 'abba' in match['matches']
 
@@ -918,7 +918,7 @@ async def test_do_complete(kernel):
     pdb_obj.completenames = lambda *ignore: ['baba']
     kernel.shell._namespace_stack = [pdb_obj]
     match = kernel.do_complete('ba', 2)
-    if isawaitable(match):
+    if inspect.isawaitable(match):
         match = await match
     assert 'baba' in match['matches']
     pdb_obj.curframe = None


### PR DESCRIPTION
Some versions of pytest do auto run async tests,
recents one do not, and marking with
`@pytest.mark.anyio` also test with multiple
runner if installed.

Handle case where do_complete is both async and
sync, and make _do_complete always async.

I only found mentions of the private _do_complete
in spyder kernel, so if present somewhere else you
might need to lift the if awaitable one level up.