### PR TITLE
PR: Display contents of string arrays

### DIFF
--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -321,7 +321,7 @@ def value_to_display(value, minmax=False, level=0):
     """Convert value for display purpose"""
     # To save current Numpy printoptions
     np_printoptions = FakeObject
-    numeric_numpy_types = get_numeric_numpy_types()
+    printable_numpy_types = get_numeric_numpy_types() + (np.str_,)
 
     try:
         if np.ndarray is not FakeObject:
@@ -344,11 +344,11 @@ def value_to_display(value, minmax=False, level=0):
                     try:
                         display = 'Min: %r\nMax: %r' % (value.min(), value.max())
                     except (TypeError, ValueError):
-                        if value.dtype.type in numeric_numpy_types:
+                        if value.dtype.type in printable_numpy_types:
                             display = str(value)
                         else:
                             display = default_display(value)
-                elif value.dtype.type in numeric_numpy_types:
+                elif value.dtype.type in printable_numpy_types:
                     display = str(value)
                 else:
                     display = default_display(value)
@@ -410,7 +410,7 @@ def value_to_display(value, minmax=False, level=0):
             display = str(value)
         elif (isinstance(value, (int, float, complex)) or
               isinstance(value, bool) or
-              isinstance(value, numeric_numpy_types)):
+              isinstance(value, printable_numpy_types)):
             display = repr(value)
         else:
             if level == 0:

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -284,6 +284,12 @@ def test_str_in_container_display():
     assert value_to_display([b'a', u'b']) == "['a', 'b']"
 
 
+def test_string_array_display():
+    """Test that an array of strings is displayed correctly."""
+    arr = np.array(['a', 'b'])
+    assert value_to_display(arr) == "['a' 'b']"
+
+
 def test_ellipses(tmpdir):
     """
     Test that we're adding a binary ellipses when value_to_display of


### PR DESCRIPTION
When displaying a NumPy array of strings, use `str` to convert the array to a string instead of using the default description "ndarray object of numpy module".

@ccordoba12 You turned off displaying the contents of string arrays in PR spyder-ide/spyder#5028 where you specified that only the contents of numeric arrays should be displayed. I presume that you did so to prevent problems with displaying arbitrary arrays, but I think string arrays are safe.

This fixes issue spyder-ide/spyder#22570.