### PR TITLE
PR: Support `frozenset` in namespace view

### DIFF
--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -222,7 +222,7 @@ def is_editable_type(value):
             'Series',
             'PIL.Image.Image',
             'datetime.date',
-            'datetime.timedelta'
+            'datetime.timedelta',
         ]
 
         if (get_type_string(value) not in supported_types and
@@ -661,7 +661,8 @@ def get_supported_types():
         tuple,
         date,
         timedelta,
-        str]
+        str,
+    ]
     try:
         from numpy import ndarray, matrix, generic
         editable_types += [ndarray, matrix, generic]

--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -203,9 +203,25 @@ def is_editable_type(value):
         return False
     else:
         supported_types = [
-            'bool', 'int', 'long', 'float', 'complex', 'list', 'set', 'dict',
-            'tuple', 'str', 'unicode', 'NDArray', 'MaskedArray', 'Matrix',
-            'DataFrame', 'Series', 'PIL.Image.Image', 'datetime.date',
+            'bool',
+            'int',
+            'long',
+            'float',
+            'complex',
+            'list',
+            'set',
+            'frozenset',
+            'dict',
+            'tuple',
+            'str',
+            'unicode',
+            'NDArray',
+            'MaskedArray',
+            'Matrix',
+            'DataFrame',
+            'Series',
+            'PIL.Image.Image',
+            'datetime.date',
             'datetime.timedelta'
         ]
 
@@ -272,7 +288,7 @@ def default_display(value, with_module=True):
 def collections_display(value, level):
     """Display for collections (i.e. list, set, tuple and dict)."""
     is_dict = isinstance(value, dict)
-    is_set = isinstance(value, set)
+    is_set = isinstance(value, (set, frozenset))
 
     # Get elements
     if is_dict:
@@ -311,6 +327,8 @@ def collections_display(value, level):
         display = '[' + display + ']'
     elif isinstance(value, set):
         display = '{' + display + '}'
+    elif isinstance(value, frozenset):
+        display = 'frozenset({' + display + '})'
     else:
         display = '(' + display + ')'
 
@@ -354,7 +372,7 @@ def value_to_display(value, minmax=False, level=0):
                     display = default_display(value)
             else:
                 display = 'Numpy array'
-        elif any([type(value) == t for t in [list, set, tuple, dict]]):
+        elif type(value) in [list, set, frozenset, tuple, dict]:
             display = collections_display(value, level+1)
         elif isinstance(value, PIL.Image.Image):
             if level == 0:
@@ -558,7 +576,7 @@ def is_supported(value, check_all=False, filters=None, iterate=False):
     elif not isinstance(value, filters):
         return False
     elif iterate:
-        if isinstance(value, (list, tuple, set)):
+        if isinstance(value, (list, tuple, set, frozenset)):
             valid_count = 0
             for val in value:
                 if is_supported(val, filters=filters, iterate=check_all):
@@ -632,8 +650,18 @@ def get_supported_types():
     in spyder-docs
     """
     from datetime import date, timedelta
-    editable_types = [int, float, complex, list, set, dict, tuple, date,
-                      timedelta, str]
+    editable_types = [
+        int,
+        float,
+        complex,
+        list,
+        set,
+        frozenset,
+        dict,
+        tuple,
+        date,
+        timedelta,
+        str]
     try:
         from numpy import ndarray, matrix, generic
         editable_types += [ndarray, matrix, generic]

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -55,8 +55,14 @@ def test_get_size():
                 return super(object, self).__getattribute__(name)
 
 
-    length = [list([1,2,3]), tuple([1,2,3]), set([1,2,3]), '123',
-              {1:1, 2:2, 3:3}, frozenset([1,2,3])]
+    length = [
+        list([1, 2, 3]),
+        tuple([1, 2, 3]),
+        set([1, 2, 3]),
+        '123',
+        {1:1, 2:2, 3:3},
+        frozenset([1, 2, 3]),
+    ]
     for obj in length:
         assert get_size(obj) == 3
 

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -56,7 +56,7 @@ def test_get_size():
 
 
     length = [list([1,2,3]), tuple([1,2,3]), set([1,2,3]), '123',
-              {1:1, 2:2, 3:3}]
+              {1:1, 2:2, 3:3}, frozenset([1,2,3])]
     for obj in length:
         assert get_size(obj) == 3
 
@@ -243,6 +243,11 @@ def test_set_display():
     assert value_to_display([long_set] * 10) == disp[:70] + ' ...'
 
 
+def test_frozenset_display():
+    """Test for display of a frozenset."""
+    assert value_to_display(frozenset({1, 2, 3})) == 'frozenset({1, 2, 3})'
+
+
 def test_datetime_display():
     """Simple tests that dates, datetimes and timedeltas display correctly."""
     test_date = datetime.date(2017, 12, 18)
@@ -323,6 +328,9 @@ def test_get_type_string():
     # Sets
     assert get_type_string({1, 2, 3}) == 'set'
 
+    # Frozensets
+    assert get_type_string(frozenset({1, 2, 3})) == 'frozenset'
+
     # Dictionaries
     assert get_type_string({'a': 1, 'b': 2}) == 'dict'
 
@@ -377,6 +385,9 @@ def test_is_editable_type():
 
     # Sets
     assert is_editable_type({1, 2, 3})
+
+    # Frozensets
+    assert is_editable_type(frozenset({1, 2, 3}))
 
     # Dictionaries
     assert is_editable_type({'a': 1, 'b': 2})


### PR DESCRIPTION
Support getting the value of a variable of type `frozenset`. The value will be shown as "frozenset({...})", similar as when you print the variable. Also add a small test for this.