### PR TITLE
PR: Support pathlib and None in namespace view

### DIFF
--- a/spyder_kernels/utils/nsview.py
+++ b/spyder_kernels/utils/nsview.py
@@ -11,6 +11,7 @@ Utilities to build a namespace view.
 """
 from itertools import islice
 import inspect
+import pathlib
 import re
 
 from spyder_kernels.utils.lazymodules import (
@@ -422,13 +423,15 @@ def value_to_display(value, minmax=False, level=0):
                     display = "'" + display + "'"
             else:
                 display = default_display(value)
-
-        elif (isinstance(value, datetime.date) or
-              isinstance(value, datetime.timedelta)):
+        elif isinstance(value, pathlib.PurePath):
             display = str(value)
-        elif (isinstance(value, (int, float, complex)) or
-              isinstance(value, bool) or
-              isinstance(value, printable_numpy_types)):
+        elif isinstance(value, (datetime.date, datetime.timedelta)):
+            display = str(value)
+        elif (
+            isinstance(value, (int, float, complex, bool))
+            or isinstance(value, printable_numpy_types)
+            or value is None
+        ):
             display = repr(value)
         else:
             if level == 0:

--- a/spyder_kernels/utils/tests/test_nsview.py
+++ b/spyder_kernels/utils/tests/test_nsview.py
@@ -13,6 +13,7 @@ Tests for utils.py
 # Standard library imports
 from collections import defaultdict
 import datetime
+import pathlib
 import sys
 
 # Third party imports
@@ -287,6 +288,17 @@ def test_datetime_display():
                               1: test_datetime,
                               2: test_timedelta_2}) ==
             ("{0:2017-12-18, 1:2017-12-18 13:43:02, 2:1:00:00}"))
+
+
+def test_path_display():
+    """Test for display of a path from pathlib."""
+    path = pathlib.PureWindowsPath('C:/') / 'Program Files'
+    assert value_to_display(path) == r'C:\Program Files'
+
+
+def test_none_display():
+    """Test for display of None."""
+    assert value_to_display(None) == 'None'
 
 
 def test_str_in_container_display():


### PR DESCRIPTION
Support variables of type `pathlib.Path` and variables containing `None` in `value_to_display()`, so that they can be displayed in Spyder's Variable Explorer. Also add tests for this.

Variables of type `pathlib.Path` are converted using `str()`. The alternative would be to use `repr()`, which results in the variable `path` in the example below to be displayed as `PosixPath('/home/jitse/spyder-kernels')`. As explained in https://github.com/spyder-ide/spyder/issues/22351#issue-2467604479:

> The repr has the advantage as it gives a clear indicator in how to instantiate a new Path.
>
>  However displaying the printed version of the str form, where the escape characters are processed has the advantage in that it matches what is typically displayed in the Operating System and is consistent to the file paths seen elsewhere in Spyder

I went with `str()` because that is what we do in the Variable Explorer for strings and arrays.

Screenshot of Variable Explorer after the PR:

![after-pathlib](https://github.com/user-attachments/assets/f7f7366c-8733-4860-ad7c-7ed05c5a8f8b)

Screenshot of current version, before the PR:

![before-pathlib](https://github.com/user-attachments/assets/ff3e205f-ed1c-4978-8f5b-d29e3c1b92a8)

