### PR TITLE
PR: Add minimal required version of `traitlets`

### DIFF
--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -3,6 +3,7 @@ ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
-wurlitzer>=1.0.3
 pyxdg>=0.26
+traitlets>=5.14.3
+wurlitzer>=1.0.3
 setuptools<71.0

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -3,4 +3,5 @@ ipykernel>=6.29.3,<7
 ipython>=8.12.2,<9
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
+traitlets>=5.14.3
 setuptools<71.0

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,12 @@ REQUIREMENTS = [
     'ipython>=8.13.0,<9,!=8.17.1; python_version>"3.8"',
     'jupyter-client>=7.4.9,<9',
     'pyzmq>=24.0.0',
-    'wurlitzer>=1.0.3;platform_system!="Windows"',
     'pyxdg>=0.26;platform_system=="Linux"',
+    # We need at least this version of traitlets to fix an error when setting
+    # the Matplotlib inline backend formats.
+    # Fixes spyder-ide/spyder#24390
+    'traitlets>=5.14.3',
+    'wurlitzer>=1.0.3;platform_system!="Windows"',
 ]
 
 TEST_REQUIREMENTS = [


### PR DESCRIPTION
- Versions between 5.12 and 5.14.2 have a nasty bug that prevents setting the Matplotlib inline backend formats.
- This is necessary to address spyder-ide/spyder#24390