### PR TITLE
PR: Add support for IPython 9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.9"
 dependencies = [
     "cloudpickle",
     "ipykernel>=6.29.3,<7",
-    "ipython>=8.13.0,<9,!=8.17.1",
+    "ipython>=8.13.0,<10,!=8.17.1",
     "jupyter-client>=7.4.9,<9",
     "pyxdg>=0.26;platform_system=='Linux'",
     "pyzmq>=24.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.9"
 dependencies = [
     "cloudpickle",
     "ipykernel>=6.29.3,<7",
-    "ipython>=8.13.0,<10,!=8.17.1",
+    "ipython>=8.13.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0",
     "jupyter-client>=7.4.9,<9",
     "packaging",
     "pyxdg>=0.26;platform_system=='Linux'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "ipykernel>=6.29.3,<7",
     "ipython>=8.13.0,<10,!=8.17.1",
     "jupyter-client>=7.4.9,<9",
+    "packaging",
     "pyxdg>=0.26;platform_system=='Linux'",
     "pyzmq>=24.0.0",
     # We need at least this version of traitlets to fix an error when setting

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7
-ipython>=8.12.2,<9
+ipython>=8.12.2,<10
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 pyxdg>=0.26

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7
-ipython>=8.13.0,<10
+ipython>=8.13.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 pyxdg>=0.26

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7
-ipython>=8.12.2,<10
+ipython>=8.13.0,<10
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 pyxdg>=0.26

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7
-ipython>=8.12.2,<9
+ipython>=8.12.2,<10
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 traitlets>=5.14.3

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7
-ipython>=8.12.2,<10
+ipython>=8.13.0,<10
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 traitlets>=5.14.3

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7
-ipython>=8.13.0,<10
+ipython>=8.13.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 traitlets>=5.14.3

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -736,11 +736,6 @@ class SpyderKernel(IPythonKernel):
                 "custom_theme",
                 None,
                 extra_style,
-                symbols={
-                    "arrow_body": "\u2500",
-                    "arrow_head": "\u25b6",
-                    "top_line": "\u2500",
-                },
             )
             IPython.utils.PyColorize.theme_table["custom_theme"] = theme
             self.shell.run_line_magic("colors", "custom_theme")

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -720,16 +720,30 @@ class SpyderKernel(IPythonKernel):
         else:
             # Create theme definition and set it as `_default`
             import IPython.utils.PyColorize
-            from IPython.utils.PyColorize import Theme
+            from IPython.utils.PyColorize import (
+                Theme,
+                linux_theme,
+                lightbg_theme,
+            )
+
+            extra_style = (
+                linux_theme.extra_style
+                if self.shell.get_spyder_theme() == "dark"
+                else lightbg_theme.extra_style
+            )
+            extra_style.update(create_pygments_dict(syntax_style))
             theme = Theme(
                 "custom_theme",
                 None,
-                create_pygments_dict(syntax_style),
+                extra_style,
+                symbols={
+                    "arrow_body": "\u2500",
+                    "arrow_head": "\u25b6",
+                    "top_line": "\u2500",
+                },
             )
             IPython.utils.PyColorize.theme_table["custom_theme"] = theme
-
-            import IPython.core.ultratb
-            IPython.core.ultratb._default = "custom_theme"
+            self.shell.run_line_magic("colors", "custom_theme")
 
     def get_cwd(self):
         """Get current working directory."""

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -712,18 +712,19 @@ class SpyderKernel(IPythonKernel):
             from IPython.utils.PyColorize import (
                 Theme,
                 linux_theme,
-                lightbg_theme,
+                neutral_theme,
             )
 
-            extra_style = (
-                linux_theme.extra_style
-                if self.shell.get_spyder_theme() == "dark"
-                else lightbg_theme.extra_style
-            )
+            base = "default"
+            extra_style = neutral_theme.extra_style
+            if self.shell.get_spyder_theme() == "dark":
+                base = "monokai"
+                extra_style = linux_theme.extra_style
+
             extra_style.update(create_pygments_dict(syntax_style))
             theme = Theme(
                 "spyder_theme",
-                None,
+                base,
                 extra_style,
             )
             IPython.utils.PyColorize.theme_table["spyder_theme"] = theme

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -707,7 +707,7 @@ class SpyderKernel(IPythonKernel):
     def set_traceback_syntax_highlighting(self, syntax_style):
         """Set the traceback syntax highlighting style."""
         if parse_version(ipython_release.version) < parse_version("9.0"):
-            # Use `tb_highlight_style` class attribute to set the style
+            # Use `tb_highlight_style` class attribute to set the style (IPython 8.x)
             import IPython.core.ultratb
             from IPython.core.ultratb import VerboseTB
 
@@ -718,7 +718,7 @@ class SpyderKernel(IPythonKernel):
             elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
                 VerboseTB._tb_highlight_style = syntax_style
         else:
-            # Create spyder theme definition and set it
+            # Create spyder theme definition and set it (IPython 9.x+)
             import IPython.utils.PyColorize
             from IPython.utils.PyColorize import (
                 Theme,

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -706,18 +706,7 @@ class SpyderKernel(IPythonKernel):
 
     def set_traceback_syntax_highlighting(self, syntax_style):
         """Set the traceback syntax highlighting style."""
-        if parse_version(ipython_release.version) < parse_version("9.0"):
-            # Use `tb_highlight_style` class attribute to set the style (IPython 8.x)
-            import IPython.core.ultratb
-            from IPython.core.ultratb import VerboseTB
-
-            IPython.core.ultratb.get_style_by_name = create_style_class
-
-            if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
-                VerboseTB.tb_highlight_style = syntax_style
-            elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
-                VerboseTB._tb_highlight_style = syntax_style
-        else:
+        if parse_version(ipython_release.version) >= parse_version("9.0"):
             # Create spyder theme definition and set it (IPython 9.x+)
             import IPython.utils.PyColorize
             from IPython.utils.PyColorize import (
@@ -739,6 +728,17 @@ class SpyderKernel(IPythonKernel):
             )
             IPython.utils.PyColorize.theme_table["spyder_theme"] = theme
             self.shell.run_line_magic("colors", "spyder_theme")
+        else:
+            # Use `tb_highlight_style` class attribute to set the style (IPython 8.x)
+            import IPython.core.ultratb
+            from IPython.core.ultratb import VerboseTB
+
+            IPython.core.ultratb.get_style_by_name = create_style_class
+
+            if getattr(VerboseTB, "tb_highlight_style", None) is not None:
+                VerboseTB.tb_highlight_style = syntax_style
+            elif getattr(VerboseTB, "_tb_highlight_style", None) is not None:
+                VerboseTB._tb_highlight_style = syntax_style
 
     def get_cwd(self):
         """Get current working directory."""

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -718,7 +718,7 @@ class SpyderKernel(IPythonKernel):
             elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
                 VerboseTB._tb_highlight_style = syntax_style
         else:
-            # Create theme definition and set it as `_default`
+            # Create spyder theme definition and set it
             import IPython.utils.PyColorize
             from IPython.utils.PyColorize import (
                 Theme,
@@ -733,12 +733,12 @@ class SpyderKernel(IPythonKernel):
             )
             extra_style.update(create_pygments_dict(syntax_style))
             theme = Theme(
-                "custom_theme",
+                "spyder_theme",
                 None,
                 extra_style,
             )
-            IPython.utils.PyColorize.theme_table["custom_theme"] = theme
-            self.shell.run_line_magic("colors", "custom_theme")
+            IPython.utils.PyColorize.theme_table["spyder_theme"] = theme
+            self.shell.run_line_magic("colors", "spyder_theme")
 
     def get_cwd(self):
         """Get current working directory."""

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -722,15 +722,12 @@ class SpyderKernel(IPythonKernel):
                 extra_style = linux_theme.extra_style
 
             extra_style.update(create_pygments_dict(syntax_style))
-            theme = Theme(
-                "spyder_theme",
-                base,
-                extra_style,
-            )
+            theme = Theme("spyder_theme", base, extra_style)
             IPython.utils.PyColorize.theme_table["spyder_theme"] = theme
             self.shell.run_line_magic("colors", "spyder_theme")
         else:
-            # Use `tb_highlight_style` class attribute to set the style (IPython 8.x)
+            # Use `tb_highlight_style` class attribute to set the style (
+            # IPython 8.x)
             import IPython.core.ultratb
             from IPython.core.ultratb import VerboseTB
 

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -27,6 +27,7 @@ import cloudpickle
 from ipykernel.ipkernel import IPythonKernel
 from ipykernel import get_connection_info
 from IPython.core import release as ipython_release
+from packaging.version import parse as parse_version
 from traitlets.config.loader import Config, LazyConfigValue
 import zmq
 from zmq.utils.garbage import gc
@@ -49,7 +50,7 @@ from spyder_kernels.utils.iofuncs import iofunctions
 from spyder_kernels.utils.mpl import automatic_backend, MPL_BACKENDS_TO_SPYDER
 from spyder_kernels.utils.nsview import (
     get_remote_data, make_remote_view, get_size)
-from spyder_kernels.utils.style import create_style_class
+from spyder_kernels.utils.style import create_pygments_dict, create_style_class
 from spyder_kernels.console.shell import SpyderShell
 from spyder_kernels.comms.utils import WriteContext
 
@@ -705,15 +706,30 @@ class SpyderKernel(IPythonKernel):
 
     def set_traceback_syntax_highlighting(self, syntax_style):
         """Set the traceback syntax highlighting style."""
-        import IPython.core.ultratb
-        from IPython.core.ultratb import VerboseTB
+        if parse_version(ipython_release.version) < parse_version("9.0"):
+            # Use `tb_highlight_style` class attribute to set the style
+            import IPython.core.ultratb
+            from IPython.core.ultratb import VerboseTB
 
-        IPython.core.ultratb.get_style_by_name = create_style_class
+            IPython.core.ultratb.get_style_by_name = create_style_class
 
-        if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
-            VerboseTB.tb_highlight_style = syntax_style
-        elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
-            VerboseTB._tb_highlight_style = syntax_style
+            if getattr(VerboseTB, 'tb_highlight_style', None) is not None:
+                VerboseTB.tb_highlight_style = syntax_style
+            elif getattr(VerboseTB, '_tb_highlight_style', None) is not None:
+                VerboseTB._tb_highlight_style = syntax_style
+        else:
+            # Create theme definition and set it as `_default`
+            import IPython.utils.PyColorize
+            from IPython.utils.PyColorize import Theme
+            theme = Theme(
+                "custom_theme",
+                None,
+                create_pygments_dict(syntax_style),
+            )
+            IPython.utils.PyColorize.theme_table["custom_theme"] = theme
+
+            import IPython.core.ultratb
+            IPython.core.ultratb._default = "custom_theme"
 
     def get_cwd(self):
         """Get current working directory."""

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -117,9 +117,9 @@ class SpyderShell(ZMQInteractiveShell):
             for line in stb:
                 if (
                     # Verbose mode
-                    re.match(r"File (.*)", line)
+                    re.match(r"\x1b(.*)File (.*)", line)
                     # Plain mode
-                    or re.match(r"\x1b\[(.*)  File (.*)", line)
+                    or re.match(r"\x1b(.*)  File (.*)", line)
                 ) and (
                     # The file line should not contain a location where
                     # Spyder-kernels is installed

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -24,6 +24,9 @@ from typing import List
 
 # Third-party imports
 from ipykernel.zmqshell import ZMQInteractiveShell
+from IPython.core import release as ipython_release
+from packaging.version import parse as parse_version
+
 
 # Local imports
 from spyder_kernels.customize.namespace_manager import NamespaceManager
@@ -141,6 +144,10 @@ class SpyderShell(ZMQInteractiveShell):
     def set_spyder_theme(self, theme):
         """Set the theme for the console."""
         self._spyder_theme = theme
+        # Call `%colors` following theme for IPython 8.x tracebacks
+        if parse_version(ipython_release.version) < parse_version("9.0"):
+            colors = "linux" if theme == "dark" else "lightbg"
+            self.shell.run_line_magic("colors", colors)
 
     def get_spyder_theme(self):
         """Get the theme for the console."""

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -148,7 +148,7 @@ class SpyderShell(ZMQInteractiveShell):
         # Call `%colors` following theme for IPython 8.x tracebacks
         if parse_version(ipython_release.version) < parse_version("9.0"):
             colors = "linux" if theme == "dark" else "lightbg"
-            self.shell.run_line_magic("colors", colors)
+            self.run_line_magic("colors", colors)
 
     def get_spyder_theme(self):
         """Get the theme for the console."""

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -139,11 +139,6 @@ class SpyderShell(ZMQInteractiveShell):
     def set_spyder_theme(self, theme):
         """Set the theme for the console."""
         self._spyder_theme = theme
-        if theme == "dark":
-            # Needed to change the colors of tracebacks
-            self.run_line_magic("colors", "linux")
-        elif theme == "light":
-            self.run_line_magic("colors", "lightbg")
 
     def get_spyder_theme(self):
         """Get the theme for the console."""

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -144,6 +144,7 @@ class SpyderShell(ZMQInteractiveShell):
     def set_spyder_theme(self, theme):
         """Set the theme for the console."""
         self._spyder_theme = theme
+
         # Call `%colors` following theme for IPython 8.x tracebacks
         if parse_version(ipython_release.version) < parse_version("9.0"):
             colors = "linux" if theme == "dark" else "lightbg"

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -117,9 +117,11 @@ class SpyderShell(ZMQInteractiveShell):
             for line in stb:
                 if (
                     # Verbose mode
-                    re.match(r"\x1b(.*)File (.*)", line)
+                    re.match(r"File (.*)", line)  # IPython 8.x
+                    or re.match(r"\x1b(.*)File (.*)", line)  # IPython 9.x
                     # Plain mode
-                    or re.match(r"\x1b(.*)  File (.*)", line)
+                    or re.match(r"\x1b\[(.*)  File (.*)", line)  # IPython 8.x
+                    or re.match(r"  File (.*)", line)  # IPython 9.x
                 ) and (
                     # The file line should not contain a location where
                     # Spyder-kernels is installed

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -29,7 +29,7 @@ while '' in sys.path:
 
 # Local imports
 from spyder_kernels.console.kernelapp import SpyderKernelApp
-from spyder_kernels.utils.misc import is_module_installed
+from spyder_kernels.utils.misc import is_module_installed, get_package_version
 
 
 def import_spydercustomize():
@@ -105,7 +105,7 @@ def kernel_config():
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
     # To disable tips (for the moment)
-    if get_package_version('ipython') and get_package_version('ipython') >= parse_version("9.0"):
+    if get_package_version('ipython') >= parse_version("9.0"):
         spy_cfg.ZMQInteractiveShell.enable_tip = False
 
     # Greedy completer

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -16,6 +16,8 @@ import os.path as osp
 import sys
 import site
 
+# Third-party imports
+from IPython.core import release as ipython_release
 from packaging.version import parse as parse_version
 
 
@@ -104,8 +106,8 @@ def kernel_config():
     # To handle the banner by ourselves
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
-    # To disable tips (for the moment)
-    if get_package_version('ipython') >= parse_version("9.0"):
+    # To disable tips (for the moment) that are only available in IPython 9.0+
+    if parse_version(ipython_release.version) >= parse_version("9.0"):
         spy_cfg.ZMQInteractiveShell.enable_tip = False
 
     # Greedy completer

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -102,7 +102,8 @@ def kernel_config():
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
     # To disable tips (for the moment)
-    spy_cfg.ZMQInteractiveShell.enable_tip = False
+    if sys.version_info[0:2] >= (3, 11):
+        spy_cfg.ZMQInteractiveShell.enable_tip = False
 
     # Greedy completer
     greedy_o = os.environ.get('SPY_GREEDY_O') == 'True'

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -31,7 +31,7 @@ while '' in sys.path:
 
 # Local imports
 from spyder_kernels.console.kernelapp import SpyderKernelApp
-from spyder_kernels.utils.misc import is_module_installed, get_package_version
+from spyder_kernels.utils.misc import is_module_installed
 
 
 def import_spydercustomize():

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -16,6 +16,9 @@ import os.path as osp
 import sys
 import site
 
+from packaging.version import parse as parse_version
+
+
 # Remove current directory from sys.path to prevent kernel crashes when people
 # name Python files or modules with the same name as standard library modules.
 # See spyder-ide/spyder#8007
@@ -102,7 +105,7 @@ def kernel_config():
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
     # To disable tips (for the moment)
-    if sys.version_info[0:2] >= (3, 11):
+    if get_package_version('ipython') and get_package_version('ipython') >= parse_version("9.0"):
         spy_cfg.ZMQInteractiveShell.enable_tip = False
 
     # Greedy completer

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -101,6 +101,9 @@ def kernel_config():
     # To handle the banner by ourselves
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
+    # To disable tips (for the moment)
+    spy_cfg.ZMQInteractiveShell.enable_tip = False
+
     # Greedy completer
     greedy_o = os.environ.get('SPY_GREEDY_O') == 'True'
     spy_cfg.IPCompleter.greedy = greedy_o

--- a/spyder_kernels/utils/misc.py
+++ b/spyder_kernels/utils/misc.py
@@ -31,6 +31,15 @@ def is_module_installed(module_name):
         return False
 
 
+def get_package_version(package_name):
+    from importlib.metadata import PackageNotFoundError, version as package_version
+    from packaging.version import parse as parse_version
+    try:
+        return parse_version(package_version(package_name))
+    except PackageNotFoundError:
+        return None
+
+
 def fix_reference_name(name, blacklist=None):
     """Return a syntax-valid Python reference name from an arbitrary name"""
     name = "".join(re.split(r'[^0-9a-zA-Z_]', name))

--- a/spyder_kernels/utils/misc.py
+++ b/spyder_kernels/utils/misc.py
@@ -31,15 +31,6 @@ def is_module_installed(module_name):
         return False
 
 
-def get_package_version(package_name):
-    from importlib.metadata import PackageNotFoundError, version as package_version
-    from packaging.version import parse as parse_version
-    try:
-        return parse_version(package_version(package_name))
-    except PackageNotFoundError:
-        return None
-
-
 def fix_reference_name(name, blacklist=None):
     """Return a syntax-valid Python reference name from an arbitrary name"""
     name = "".join(re.split(r'[^0-9a-zA-Z_]', name))


### PR DESCRIPTION
Fixes #543
Part of https://github.com/spyder-ide/spyder/issues/23911
Related with https://github.com/spyder-ide/spyder/pull/24806

TODO:

* [x] Changes IPython upper constraint to <10, and skip 9.1 to 9.4 versions due to https://github.com/ipython/ipython/issues/14937
* [x] Disable tips feature (for the moment since seems like sometimes they get truncated with the banner)
* [x] Fix spyder-kernels traceback frame skip
* [x] Check updates needed for traceback highlighting handling with IPython 9.x