### PR TITLE
PR: Bump minimal supported IPython version to 8.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.9"
 dependencies = [
     "cloudpickle",
     "ipykernel>=6.29.3,<7",
-    "ipython>=8.13.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0",
+    "ipython>=8.15.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0",
     "jupyter-client>=7.4.9,<9",
     "packaging",
     "pyxdg>=0.26;platform_system=='Linux'",


### PR DESCRIPTION
- Needed for spyder-ide/spyder#25034.