### PR TITLE
PR: Remove overridden `set_trace` in `SpyderPdb` because it's not needed

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -7,17 +7,20 @@
 
 """Spyder debugger."""
 
+from __future__ import annotations
+
 import ast
 import bdb
 import builtins
 from contextlib import contextmanager
+from collections import namedtuple
+from functools import lru_cache
 import logging
 import os
 import sys
 import traceback
 import threading
-from collections import namedtuple
-from functools import lru_cache
+import typing
 
 from IPython.core.autocall import ZMQExitAutocall
 from IPython.core.debugger import Pdb as ipyPdb
@@ -27,8 +30,14 @@ import spyder_kernels
 from spyder_kernels.comms.commbase import stacksummary_to_json
 from spyder_kernels.comms.frontendcomm import CommError, frontend_request
 from spyder_kernels.customize.utils import (
-    path_is_library, capture_last_Expr, exec_encapsulate_locals
+    path_is_library,
+    capture_last_Expr,
+    exec_encapsulate_locals,
 )
+
+
+if typing.TYPE_CHECKING:
+    from spyder_kernels.console.shell import SpyderShell
 
 
 logger = logging.getLogger(__name__)
@@ -85,7 +94,9 @@ class SpyderPdb(ipyPdb):
         self._exclamation_warning_printed = False
         self.pdb_stop_first_line = True
         self._disable_next_stack_entry = False
-        super(SpyderPdb, self).__init__()
+        self.shell: SpyderShell | None = None
+
+        super().__init__()
 
         # content of tuple: (filename, line number)
         self._previous_step = None


### PR DESCRIPTION
The purpose of that was to add a `pdb_session` when called (via `breakpoint()`), but that's now done by `DebugWrapper`.