### PR TITLE
PR: Fix debugger stop in breakpoints set on modules if stop on first line option is disabled

### DIFF
--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -287,6 +287,7 @@ class SpyderPdb(ipyPdb):
         if self.stopframe == self.botframe and self.stoplineno == -1:
             return False
         if self.continue_if_has_breakpoints and self.should_continue(frame):
+            self._wait_for_mainpyfile = False
             self.set_continue()
             return False
         if (


### PR DESCRIPTION
This PR addresses spyder-ide/spyder#22025. This is not the fix we have been using internally for some time. Looking at it again I came up with a simpler and (hopefully) better fix.

The commit has a detailed explanation. It's … somewhat convoluted due to many layers being involved (Python's `pdb.Pdb`/`bdb.Bdb` and Spyder's customizations).

Please verify the fix, maybe @impact27 can give a hand. Unfortunately, I won't able to respond in the next two weeks to come.