### PR TITLE
PR: Skip `test_get_interactive_backend` in Python 3.9 and Linux

### DIFF
--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -635,9 +635,6 @@ if __name__ == '__main__':
 
 @pytest.mark.flaky(max_runs=3)
 @pytest.mark.skipif(
-    sys.platform == 'darwin' and sys.version_info[:2] == (3, 8),
-    reason="Fails on Mac with Python 3.8")
-@pytest.mark.skipif(
     os.environ.get('USE_CONDA') != 'true',
     reason="Doesn't work with pip packages")
 def test_dask_multiprocessing(tmpdir):
@@ -756,9 +753,6 @@ def test_runfile(tmpdir):
 
 
 @pytest.mark.flaky(max_runs=3)
-@pytest.mark.skipif(
-    sys.platform == 'darwin' and sys.version_info[:2] == (3, 8),
-    reason="Fails on Mac with Python 3.8")
 def test_np_threshold(kernel):
     """
     Test that setting Numpy threshold doesn't make the Variable Explorer slow.
@@ -1185,6 +1179,10 @@ def test_locals_globals_in_pdb(kernel):
 @pytest.mark.skipif(
     os.environ.get('USE_CONDA') != 'true',
     reason="Doesn't work with pip packages"
+)
+@pytest.mark.skipif(
+    sys.version_info[:2] == (3, 9) and sys.platform.startswith("linux"),
+    reason="Fails with Python 3.9 on Linux"
 )
 def test_get_interactive_backend(backend):
     """


### PR DESCRIPTION
- That test started to fail without a clear reason.
- Also, remove some skip conditions that don't apply anymore.