### PR TITLE
PR: Raise error in get_value for subclasses of set

### DIFF
--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -385,6 +385,12 @@ class SpyderKernel(IPythonKernel):
             value = value.to_pandas()
 
         if encoded:
+            # See spyder-ide/spyder#24395
+            if isinstance(value, set) and type(value) is not set:
+                raise TypeError(
+                    "Classes inheriting from `set` cannot be safely pickled"
+                )
+
             # Encode with cloudpickle
             value = cloudpickle.dumps(value)
         return value

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -361,6 +361,18 @@ def test_get_value_with_polars(kernel):
     assert_series_equal(kernel.get_value('polars_s'), pandas_s)
 
 
+def test_get_value_with_subclass_of_set(kernel):
+    command = """
+    class my_set(set):
+        def __init__(self, *args):
+            super().__init__(*args)
+    ms = my_set()
+    """
+    asyncio.run(kernel.do_execute(command, True))
+    with pytest.raises(TypeError):
+        kernel.get_value('ms', encoded=True)
+
+
 def test_set_value(kernel):
     """Test setting the value of a variable."""
     name = 'a'


### PR DESCRIPTION
Also add a test for this.

The reason for this is that unpickling can cause a crash in Spyder if the Python versions don't match, see spyder-ide/spyder#24395.

I'm marking this as draft because I want to discuss some details on the Spyder issue.