### PR TITLE
PR: Use `curframe.f_locals` instead of `curframe_locals` in debugger for newer Python versions

### DIFF
--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -297,7 +297,10 @@ class SpyderShell(ZMQInteractiveShell):
         for session in self._namespace_stack[::-1]:
             if isinstance(session, SpyderPdb) and session.curframe is not None:
                 if frame is None or frame == session.curframe:
-                    return session.curframe_locals
+                    if sys.version_info[:2] <= (3, 12):
+                        return session.curframe_locals
+                    else:
+                        return session.curframe.f_locals
             elif frame is None and isinstance(session, NamespaceManager):
                 return session.ns_locals
 

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -979,7 +979,8 @@ def test_comprehensions_with_locals_in_pdb(kernel):
     """
     pdb_obj = SpyderPdb()
     pdb_obj.curframe = inspect.currentframe()
-    pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
     kernel.shell._namespace_stack = [pdb_obj]
 
     # Create a local variable.
@@ -995,7 +996,8 @@ def test_comprehensions_with_locals_in_pdb(kernel):
     assert kernel.get_value('in_globals') is False
 
     pdb_obj.curframe = None
-    pdb_obj.curframe_locals = None
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = None
 
 
 def test_comprehensions_with_locals_in_pdb_2(kernel):
@@ -1006,7 +1008,8 @@ def test_comprehensions_with_locals_in_pdb_2(kernel):
     """
     pdb_obj = SpyderPdb()
     pdb_obj.curframe = inspect.currentframe()
-    pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
     kernel.shell._namespace_stack = [pdb_obj]
 
     # Create a local variable.
@@ -1020,7 +1023,8 @@ def test_comprehensions_with_locals_in_pdb_2(kernel):
     assert kernel.get_value('res') == [[(1, 3), (1, 4)], [(2, 3), (2, 4)]]
 
     pdb_obj.curframe = None
-    pdb_obj.curframe_locals = None
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = None
 
 
 def test_namespaces_in_pdb(kernel):
@@ -1032,7 +1036,8 @@ def test_namespaces_in_pdb(kernel):
     kernel.shell.user_ns["test"] = 0
     pdb_obj = SpyderPdb()
     pdb_obj.curframe = inspect.currentframe()
-    pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
     kernel.shell._namespace_stack = [pdb_obj]
 
     # Check adding something to globals works
@@ -1055,7 +1060,10 @@ def test_namespaces_in_pdb(kernel):
     assert not pdb_obj._error_occured
 
     # Test locals are visible
-    pdb_obj.curframe_locals["test4"] = 0
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals["test4"] = 0
+    else:
+        pdb_obj.curframe.f_locals["test4"] = 0
     pdb_obj.default("%timeit test4")
     assert not pdb_obj._error_occured
 
@@ -1064,7 +1072,8 @@ def test_namespaces_in_pdb(kernel):
     assert pdb_obj._error_occured
 
     pdb_obj.curframe = None
-    pdb_obj.curframe_locals = None
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = None
 
 
 def test_functions_with_locals_in_pdb(kernel):
@@ -1075,7 +1084,7 @@ def test_functions_with_locals_in_pdb(kernel):
     """
     pdb_obj = SpyderPdb()
 
-    if sys.version_info[:2] >= (3, 14):
+    if sys.version_info[:2] >= (3, 13):
         Frame = namedtuple("Frame", ["f_globals", "f_locals"])
         pdb_obj.curframe = Frame(
             f_globals=kernel.shell.user_ns,
@@ -1104,7 +1113,8 @@ def test_functions_with_locals_in_pdb(kernel):
     assert kernel.get_value('zz') == 1
 
     pdb_obj.curframe = None
-    pdb_obj.curframe_locals = None
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = None
 
 
 def test_functions_with_locals_in_pdb_2(kernel):
@@ -1116,7 +1126,8 @@ def test_functions_with_locals_in_pdb_2(kernel):
     baba = 1  # noqa
     pdb_obj = SpyderPdb()
     pdb_obj.curframe = inspect.currentframe()
-    pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
     kernel.shell._namespace_stack = [pdb_obj]
 
     # Create a local function.
@@ -1143,7 +1154,8 @@ def test_functions_with_locals_in_pdb_2(kernel):
     assert "baba" not in kernel.get_value('gg')
 
     pdb_obj.curframe = None
-    pdb_obj.curframe_locals = None
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = None
 
 
 def test_locals_globals_in_pdb(kernel):
@@ -1153,7 +1165,8 @@ def test_locals_globals_in_pdb(kernel):
     a = 1  # noqa
     pdb_obj = SpyderPdb()
     pdb_obj.curframe = inspect.currentframe()
-    pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = pdb_obj.curframe.f_locals
     kernel.shell._namespace_stack = [pdb_obj]
 
     assert kernel.get_value('a') == 1
@@ -1185,7 +1198,8 @@ def test_locals_globals_in_pdb(kernel):
     assert kernel.get_value('test') is True
 
     pdb_obj.curframe = None
-    pdb_obj.curframe_locals = None
+    if sys.version_info[:2] <= (3, 12):
+        pdb_obj.curframe_locals = None
 
 
 @pytest.mark.flaky(max_runs=3)

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -83,7 +83,8 @@ class SpyderPdb(ipyPdb):
 
     def __init__(self, *args, **kwargs):
         """Init Pdb."""
-        self.curframe_locals = None
+        if sys.version_info[:2] <= (3, 12):
+            self.curframe_locals = None
         # Only set to true when calling debugfile
         self.continue_if_has_breakpoints = False
         self.pdb_ignore_lib = False
@@ -159,7 +160,10 @@ class SpyderPdb(ipyPdb):
             if cmd == "debug":
                 return self.do_debug(arg)
 
-        local_ns = self.curframe_locals
+        if sys.version_info[:2] >= (3, 13):
+            local_ns = self.curframe.f_locals
+        else:
+            local_ns = self.curframe_locals
         global_ns = self.curframe.f_globals
 
         if self.pdb_use_exclamation_mark:
@@ -421,12 +425,22 @@ class SpyderPdb(ipyPdb):
         if ipython_do_complete:
             # Make complete call with current frame
             if self.curframe:
-                if self.curframe_locals:
-                    Frame = namedtuple("Frame", ["f_locals", "f_globals"])
-                    frame = Frame(self.curframe_locals,
-                                  self.curframe.f_globals)
+                if sys.version_info[:2] >= (3, 13):
+                    if self.curframe.f_locals:
+                        Frame = namedtuple("Frame", ["f_locals", "f_globals"])
+                        frame = Frame(
+                            self.curframe.f_locals, self.curframe.f_globals
+                        )
+                    else:
+                        frame = self.curframe
                 else:
-                    frame = self.curframe
+                    if self.curframe_locals:
+                        Frame = namedtuple("Frame", ["f_locals", "f_globals"])
+                        frame = Frame(
+                            self.curframe_locals, self.curframe.f_globals
+                        )
+                    else:
+                        frame = self.curframe
                 self.shell.set_completer_frame(frame)
             result = await self.shell.kernel._do_complete(code, cursor_pos)
             # Reset frame


### PR DESCRIPTION
From the python 3.14 changelog:

The undocumented pdb.Pdb.curframe_locals attribute is now a deprecated read-only property, which will be removed in a future version of Python. The low overhead dynamic frame locals access added in Python 3.13 by PEP 667 means the frame locals cache reference previously stored in this attribute is no longer needed. Derived debuggers should access pdb.Pdb.curframe.f_locals directly in Python 3.13 and later versions.