### PR TITLE
PR: Use generic args/kwargs in `SpyderPdb` init method

### DIFF
--- a/.github/workflows/linux-pip-tests.yml
+++ b/.github/workflows/linux-pip-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.12']
+        PYTHON_VERSION: ['3.9', '3.12', '3.14']
     timeout-minutes: 20
     steps:
       - name: Checkout branch

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,6 +5,7 @@ matplotlib
 mock
 numpy
 pandas
+pip
 polars
 pyarrow
 pytest

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1074,9 +1074,18 @@ def test_functions_with_locals_in_pdb(kernel):
     This is a regression test for spyder-ide/spyder-kernels#345
     """
     pdb_obj = SpyderPdb()
-    Frame = namedtuple("Frame", ["f_globals"])
-    pdb_obj.curframe = Frame(f_globals=kernel.shell.user_ns)
-    pdb_obj.curframe_locals = kernel.shell.user_ns
+
+    if sys.version_info[:2] >=(3, 14):
+        Frame = namedtuple("Frame", ["f_globals", "f_locals"])
+        pdb_obj.curframe = Frame(
+            f_globals=kernel.shell.user_ns,
+            f_locals=kernel.shell.user_ns
+        )
+    else:
+        Frame = namedtuple("Frame", ["f_globals"])
+        pdb_obj.curframe = Frame(f_globals=kernel.shell.user_ns)
+        pdb_obj.curframe_locals = kernel.shell.user_ns
+
     kernel.shell._namespace_stack = [pdb_obj]
 
     # Create a local function.

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -81,8 +81,7 @@ class SpyderPdb(ipyPdb):
      - Add completion to non-command code.
     """
 
-    def __init__(self, completekey='tab', stdin=None, stdout=None,
-                 skip=None, nosigint=False):
+    def __init__(self, *args, **kwargs):
         """Init Pdb."""
         self.curframe_locals = None
         # Only set to true when calling debugfile


### PR DESCRIPTION
- That fixes an error when doing `breakpoint()` calls in Python 3.14.
- It also prevents issues in the future when args are changed in super classes.
- Also, start testing with Python 3.14.