### PR TITLE
PR: Increase min Python version tested on Windows to 3.10 on CI

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.12']
+        PYTHON_VERSION: ['3.10', '3.12']
     timeout-minutes: 25
     steps:
       - name: Checkout branch


### PR DESCRIPTION
A single test started to fail on 3.9 but it couldn't be possible to fix it because that version reached end-of-life last year.