### PR TITLE
PR: Drop support for Python 3.9 and 3.10 and bump IPython requirement to 9.15.0+

### DIFF
--- a/.github/workflows/linux-pip-tests.yml
+++ b/.github/workflows/linux-pip-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.12', '3.14']
+        PYTHON_VERSION: ['3.11', '3.12', '3.14']
     timeout-minutes: 20
     steps:
       - name: Checkout branch

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.12']
+        PYTHON_VERSION: ['3.11', '3.13']
     timeout-minutes: 20
     steps:
       - name: Checkout branch

--- a/.github/workflows/macos-tests.yml
+++ b/.github/workflows/macos-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.9', '3.12']
+        PYTHON_VERSION: ['3.11', '3.13']
     timeout-minutes: 25
     steps:
       - name: Checkout branch

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        PYTHON_VERSION: ['3.10', '3.12']
+        PYTHON_VERSION: ['3.11', '3.13']
     timeout-minutes: 25
     steps:
       - name: Checkout branch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Interpreters",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "cloudpickle",
     "ipykernel>=6.29.3,<7.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires-python = ">=3.11"
 dependencies = [
     "cloudpickle",
     "ipykernel>=6.29.3,<7.3.0",
-    "ipython>=8.15.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0",
+    "ipython>=9.15.0,<10",
     "jupyter-client>=7.4.9,<9",
     "packaging",
     "pyxdg>=0.26;platform_system=='Linux'",

--- a/requirements/posix.txt
+++ b/requirements/posix.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7.3.0
-ipython>=8.13.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0
+ipython>=9.15.0,<10
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 pyxdg>=0.26

--- a/requirements/windows.txt
+++ b/requirements/windows.txt
@@ -1,6 +1,6 @@
 cloudpickle
 ipykernel>=6.29.3,<7.3.0
-ipython>=8.13.0,<10,!=8.17.1,!=9.1.0,!=9.2.0,!=9.3.0,!=9.4.0
+ipython>=9.15.0,<10
 jupyter_client>=7.4.9,<9
 pyzmq>=24.0.0
 traitlets>=5.14.3

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -27,7 +27,6 @@ import cloudpickle
 from ipykernel.ipkernel import IPythonKernel
 from ipykernel import get_connection_info
 from IPython.core import release as ipython_release
-from packaging.version import parse as parse_version
 from traitlets.config.loader import Config, LazyConfigValue
 import zmq
 from zmq.utils.garbage import gc
@@ -50,7 +49,7 @@ from spyder_kernels.utils.iofuncs import iofunctions
 from spyder_kernels.utils.mpl import automatic_backend, MPL_BACKENDS_TO_SPYDER
 from spyder_kernels.utils.nsview import (
     get_remote_data, make_remote_view, get_size)
-from spyder_kernels.utils.style import create_pygments_dict, create_style_class
+from spyder_kernels.utils.style import create_pygments_dict
 from spyder_kernels.console.shell import SpyderShell
 from spyder_kernels.comms.utils import WriteContext
 
@@ -704,37 +703,24 @@ class SpyderKernel(IPythonKernel):
 
     def set_traceback_syntax_highlighting(self, syntax_style):
         """Set the traceback syntax highlighting style."""
-        if parse_version(ipython_release.version) >= parse_version("9.0"):
-            # Create spyder theme definition and set it (IPython 9.x+)
-            import IPython.utils.PyColorize
-            from IPython.utils.PyColorize import (
-                Theme,
-                linux_theme,
-                neutral_theme,
-            )
+        # Create spyder theme definition and set it
+        import IPython.utils.PyColorize
+        from IPython.utils.PyColorize import (
+            Theme,
+            linux_theme,
+            neutral_theme,
+        )
 
-            base = "default"
-            extra_style = neutral_theme.extra_style
-            if self.shell.get_spyder_theme() == "dark":
-                base = "monokai"
-                extra_style = linux_theme.extra_style
+        base = "default"
+        extra_style = neutral_theme.extra_style
+        if self.shell.get_spyder_theme() == "dark":
+            base = "monokai"
+            extra_style = linux_theme.extra_style
 
-            extra_style.update(create_pygments_dict(syntax_style))
-            theme = Theme("spyder_theme", base, extra_style)
-            IPython.utils.PyColorize.theme_table["spyder_theme"] = theme
-            self.shell.run_line_magic("colors", "spyder_theme")
-        else:
-            # Use `tb_highlight_style` class attribute to set the style (
-            # IPython 8.x)
-            import IPython.core.ultratb
-            from IPython.core.ultratb import VerboseTB
-
-            IPython.core.ultratb.get_style_by_name = create_style_class
-
-            if getattr(VerboseTB, "tb_highlight_style", None) is not None:
-                VerboseTB.tb_highlight_style = syntax_style
-            elif getattr(VerboseTB, "_tb_highlight_style", None) is not None:
-                VerboseTB._tb_highlight_style = syntax_style
+        extra_style.update(create_pygments_dict(syntax_style))
+        theme = Theme("spyder_theme", base, extra_style)
+        IPython.utils.PyColorize.theme_table["spyder_theme"] = theme
+        self.shell.run_line_magic("colors", "spyder_theme")
 
     def get_cwd(self):
         """Get current working directory."""

--- a/spyder_kernels/console/kernel.py
+++ b/spyder_kernels/console/kernel.py
@@ -669,12 +669,7 @@ class SpyderKernel(IPythonKernel):
             elif key == "color scheme":
                 self.set_color_scheme(value)
             elif key == "traceback_highlight_style":
-                # This doesn't work in Python 3.8 because the last IPython
-                # version compatible with it doesn't allow to customize the
-                # syntax highlighting scheme used for tracebacks.
-                # Fixes spyder-ide/spyder#23484
-                if sys.version_info >= (3, 9):
-                    self.set_traceback_syntax_highlighting(value)
+                self.set_traceback_syntax_highlighting(value)
             elif key == "jedi_completer":
                 self.set_jedi_completer(value)
             elif key == "greedy_completer":

--- a/spyder_kernels/console/shell.py
+++ b/spyder_kernels/console/shell.py
@@ -24,9 +24,6 @@ from typing import List
 
 # Third-party imports
 from ipykernel.zmqshell import ZMQInteractiveShell
-from IPython.core import release as ipython_release
-from packaging.version import parse as parse_version
-
 
 # Local imports
 from spyder_kernels.customize.namespace_manager import NamespaceManager
@@ -144,11 +141,6 @@ class SpyderShell(ZMQInteractiveShell):
     def set_spyder_theme(self, theme):
         """Set the theme for the console."""
         self._spyder_theme = theme
-
-        # Call `%colors` following theme for IPython 8.x tracebacks
-        if parse_version(ipython_release.version) < parse_version("9.0"):
-            colors = "linux" if theme == "dark" else "lightbg"
-            self.run_line_magic("colors", colors)
 
     def get_spyder_theme(self):
         """Get the theme for the console."""

--- a/spyder_kernels/console/start.py
+++ b/spyder_kernels/console/start.py
@@ -16,11 +16,6 @@ import os.path as osp
 import sys
 import site
 
-# Third-party imports
-from IPython.core import release as ipython_release
-from packaging.version import parse as parse_version
-
-
 # Remove current directory from sys.path to prevent kernel crashes when people
 # name Python files or modules with the same name as standard library modules.
 # See spyder-ide/spyder#8007
@@ -107,8 +102,7 @@ def kernel_config():
     spy_cfg.ZMQInteractiveShell.banner1 = ''
 
     # To disable tips (for the moment) that are only available in IPython 9.0+
-    if parse_version(ipython_release.version) >= parse_version("9.0"):
-        spy_cfg.ZMQInteractiveShell.enable_tip = False
+    spy_cfg.ZMQInteractiveShell.enable_tip = False
 
     # Greedy completer
     greedy_o = os.environ.get('SPY_GREEDY_O') == 'True'

--- a/spyder_kernels/console/tests/test_console_kernel.py
+++ b/spyder_kernels/console/tests/test_console_kernel.py
@@ -1208,10 +1208,6 @@ def test_locals_globals_in_pdb(kernel):
     os.environ.get('USE_CONDA') != 'true',
     reason="Doesn't work with pip packages"
 )
-@pytest.mark.skipif(
-    sys.version_info[:2] == (3, 9) and sys.platform.startswith("linux"),
-    reason="Fails with Python 3.9 on Linux"
-)
 def test_get_interactive_backend(backend):
     """
     Test that we correctly get the interactive backend set in the kernel.

--- a/spyder_kernels/customize/spydercustomize.py
+++ b/spyder_kernels/customize/spydercustomize.py
@@ -21,8 +21,7 @@ from spyder_kernels.customize.spyderpdb import SpyderPdb
 
 # =============================================================================
 # sys.argv can be missing when Python is embedded, taking care of it.
-# Fixes Issue 1473 and other crazy crashes with IPython 0.13 trying to
-# access it.
+# Fixes spyder-ide/spyder#1473 and other crazy crashes trying to access it.
 # =============================================================================
 if not hasattr(sys, 'argv'):
     sys.argv = ['']

--- a/spyder_kernels/customize/spyderpdb.py
+++ b/spyder_kernels/customize/spyderpdb.py
@@ -101,8 +101,7 @@ class SpyderPdb(ipyPdb):
         # content of tuple: (filename, line number)
         self._previous_step = None
 
-        # Don't report hidden frames for IPython 7.24+. This attribute
-        # has no effect in previous versions.
+        # Don't report hidden frames
         self.report_skipped = False
 
         # Keep track of remote filename


### PR DESCRIPTION
Thanks to dropping support for those old Python versions, we can increase the IPython requirement, which is necessary to get some important fixes to our debugger for Python 3.14.