### PR TITLE
PR: Add other Qt bindings to automatic backend detection

### DIFF
--- a/spyder_kernels/utils/mpl.py
+++ b/spyder_kernels/utils/mpl.py
@@ -31,7 +31,10 @@ MPL_BACKENDS_TO_SPYDER = {
 
 def automatic_backend():
     """Get Matplolib automatic backend option."""
-    if is_module_installed('PyQt5'):
+    if any(
+        is_module_installed(qt_binding)
+        for qt_binding in ('PyQt5', 'PySide2', 'PyQt6', 'PySide6')
+    ):
         auto_backend = 'qt'
     elif is_module_installed('_tkinter'):
         auto_backend = 'tk'


### PR DESCRIPTION
Updates logic to be more inclusive when deciding between `qt` and `tk`. Useful for https://github.com/spyder-ide/spyder/pull/25422